### PR TITLE
Zoom over images

### DIFF
--- a/ios/AirMaps/AIRMap.m
+++ b/ios/AirMaps/AIRMap.m
@@ -155,7 +155,16 @@ const CGFloat AIRMapZoomBoundBuffer = 0.01;
     UIView *calloutMaybe = [self.calloutView hitTest:[self.calloutView convertPoint:point fromView:self] withEvent:event];
     if (calloutMaybe) return calloutMaybe;
 
-    return [super hitTest:point withEvent:event];
+    // If it's not a callout, then always return the MKNewAnnotationContainerView which will handle pinch & zoom properly
+    // - MKMapView
+    // - - UIView
+    // - - - MKBasicMapView
+    // - - - - _MKMapLayerHostingView
+    // - - - MKScrollContainerView
+    // - - - - MKOverlayContainerView
+    // - - - MKNewAnnotationContainerView
+    // - - MKAttributionLabel
+    return ((UIView *)[((UIView *)[self.subviews objectAtIndex:0]).subviews objectAtIndex:2]);
 }
 
 #pragma mark SMCalloutViewDelegate

--- a/ios/AirMaps/AIRMapMarker.m
+++ b/ios/AirMaps/AIRMapMarker.m
@@ -215,6 +215,7 @@
                                                                          clipped:YES
                                                                       resizeMode:RCTResizeModeCenter
                                                                    progressBlock:nil
+                                                                partialLoadBlock:nil
                                                                  completionBlock:^(NSError *error, UIImage *image) {
                                                                      if (error) {
                                                                          // TODO(lmr): do something with the error?


### PR DESCRIPTION
This change allows the map to respond properly to pan and zoom gestures that originate over Image markers, and would close #522.

There are probably consequences to the way this fix is implemented:
- Some gestures may not work properly for markers, such as dragging/moving, ~~although single taps seem to still be received~~ no events respond besides tapping to reveal a callout. Taps within the callout work though
- Perhaps we should call `super.hitTest` anyways, to check for  nil so that we don’t respond to non-map related events
- If apple changed the order or hierarchy of subviews, well this would obviously break
