### PR TITLE
[xcodeproj] Header search paths for standalone and workspace build.

### DIFF
--- a/lib/ios/AirMaps.xcodeproj/project.pbxproj
+++ b/lib/ios/AirMaps.xcodeproj/project.pbxproj
@@ -309,8 +309,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/../../react-native/React/**",
-					"$(SRCROOT)/../../react-native/Libraries/Image",
+					"$(SRCROOT)/../../../react-native/React/**",
+					"$(SRCROOT)/../../../react-native/Libraries/Image",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_LDFLAGS = "-ObjC";
@@ -323,8 +323,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/../../react-native/React/**",
-					"$(SRCROOT)/../../react-native/Libraries/Image",
+					"$(SRCROOT)/../../../react-native/React/**",
+					"$(SRCROOT)/../../../react-native/Libraries/Image",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				OTHER_LDFLAGS = "-ObjC";

--- a/lib/ios/AirMaps.xcodeproj/project.pbxproj
+++ b/lib/ios/AirMaps.xcodeproj/project.pbxproj
@@ -309,6 +309,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
+					"$(BUILT_PRODUCTS_DIR)",
 					"$(SRCROOT)/../../../react-native/React/**",
 					"$(SRCROOT)/../../../react-native/Libraries/Image",
 				);
@@ -323,6 +324,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
+					"$(BUILT_PRODUCTS_DIR)",
 					"$(SRCROOT)/../../../react-native/React/**",
 					"$(SRCROOT)/../../../react-native/Libraries/Image",
 				);


### PR DESCRIPTION
* I have actually not been able to build the product of the xcode project in this repo, but it was quite evident that the relative paths weren’t updated to reflect the project restructuring you recently made. Can you verify that it builds and explain to me how it is supposed to be build in a standalone fashion?

* Fixes the build when the project is included in a Xcode workspace that also includes React. This applies to CocoaPods installations of React as well.