### PR TITLE
Fixed crash caused by Android map lifecycle methods being called out of order.

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -82,7 +82,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     private final GestureDetectorCompat gestureDetector;
     private final AirMapManager manager;
     private LifecycleEventListener lifecycleListener;
-    private boolean paused = false;
+    private boolean paused = true;
     private boolean destroyed = false;
     private final ThemedReactContext context;
     private final EventDispatcher eventDispatcher;
@@ -124,7 +124,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
         this.context = reactContext;
 
         super.onCreate(null);
-        // TODO(lmr): what about onStart????
+        super.onStart();
         super.onResume();
         super.getMapAsync(this);
 
@@ -294,6 +294,10 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     lifecycleListener = new LifecycleEventListener() {
         @Override
         public void onHostResume() {
+          if (!paused || destroyed)
+          {
+              return;
+          }
           if (hasPermissions()) {
             //noinspection MissingPermission
             map.setMyLocationEnabled(showUserLocation);
@@ -306,6 +310,10 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
 
         @Override
         public void onHostPause() {
+          if (paused || destroyed)
+          {
+              return;
+          }
           if (hasPermissions()) {
             //noinspection MissingPermission
             map.setMyLocationEnabled(false);
@@ -349,6 +357,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
             onPause();
             paused = true;
         }
+        onStop();
         onDestroy();
     }
 


### PR DESCRIPTION
We found an intermittent crash caused by `LifecycleEventListener.onHostResume` being called after `doDestroy`. This caused an internal crash in `MapView`, presumably due to its `onResume` method being called after `onDestroy`.

Crash was as follows:

```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke interface method 'void com.google.maps.api.android.lib6.impl.bq.o()' on a null object reference
       at com.google.maps.api.android.lib6.impl.da.b(:com.google.android.gms.DynamiteModulesB:96)
       at com.google.android.gms.maps.internal.z.onTransact(:com.google.android.gms.DynamiteModulesB:73)
       at android.os.Binder.transact(Binder.java:380)
       at com.google.android.gms.maps.internal.IMapViewDelegate$zza$zza.onResume(Unknown Source)
       at com.google.android.gms.maps.MapView$zza.onResume(Unknown Source)
       at com.google.android.gms.dynamic.zza$7.zzb(Unknown Source)
       at com.google.android.gms.dynamic.zza.zza(Unknown Source)
       at com.google.android.gms.dynamic.zza.onResume(Unknown Source)
       at com.google.android.gms.maps.MapView.onResume(Unknown Source)
       at com.airbnb.android.react.maps.AirMapView$12.onHostResume(AirMapView.java:302)
       at com.facebook.react.bridge.ReactContext$1.run(ReactContext.java:165)
       at android.os.Handler.handleCallback(Handler.java:739)
       at android.os.Handler.dispatchMessage(Handler.java:95)
       at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:31)
       at android.os.Looper.loop(Looper.java:135)
       at android.app.ActivityThread.main(ActivityThread.java:5272)
       at java.lang.reflect.Method.invoke(Method.java)
       at java.lang.reflect.Method.invoke(Method.java:372)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:909)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:704)
```

This PR also adds in previously missing `onStart` and `onStop` calls: the [docs](https://developers.google.com/android/reference/com/google/android/gms/maps/MapView) expect the MapView to receive the lifecycle methods of its parent activity or fragment, and so we should try to replicate such a lifecycle as closely as possible with the `AirMapView`.