### PR TITLE
fix_fire_twice_onRegionChangeComplete

### DIFF
--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -446,7 +446,7 @@ class MapView extends React.Component {
   }
 
   _onMapReady() {
-    if (this.state.isReady) return
+    if (this.state.isReady) return;
 
     const { region, initialRegion, onMapReady } = this.props;
     if (region) {

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -446,6 +446,8 @@ class MapView extends React.Component {
   }
 
   _onMapReady() {
+    if ( this.state.isReady ) return
+
     const { region, initialRegion, onMapReady } = this.props;
     if (region) {
       this.map.setNativeProps({ region });

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -446,7 +446,7 @@ class MapView extends React.Component {
   }
 
   _onMapReady() {
-    if ( this.state.isReady ) return
+    if (this.state.isReady) return
 
     const { region, initialRegion, onMapReady } = this.props;
     if (region) {


### PR DESCRIPTION
Hello!

I guess I've found answer for fix these: https://github.com/airbnb/react-native-maps/issues/1596 & https://github.com/airbnb/react-native-maps/issues/1577

```onRegionChangeComplete``` fired again when next tiles are loaded.

According to these comments:
<img width="729" alt="screen shot 2017-08-26 at 14 50 02" src="https://user-images.githubusercontent.com/11584712/29741070-5837a552-8a6e-11e7-882e-c3753215434e.png">
in this commit https://github.com/airbnb/react-native-maps/commit/8a86e9899dc5674516e5fea374ae307d59732bdc