### PR TITLE
fix: custom region glitch

### DIFF
--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -451,6 +451,9 @@ class MapView extends React.Component {
 
   _onMapReady() {
     const { region, initialRegion, onMapReady } = this.props;
+    if (this.state.isReady) {
+      return;
+    }
     if (region) {
       this.map.setNativeProps({ region });
     } else if (initialRegion) {


### PR DESCRIPTION
When using controlled region, the Map sometimes go to a previous position! 
#1680