### PR TITLE
Update the Google Maps custom map style if changed after initialization

### DIFF
--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -445,6 +445,10 @@ class MapView extends React.Component {
   }
 
   componentWillUpdate(nextProps) {
+    if (nextProps.customMapStyle !== this.props.customMapStyle) {
+      this._updateStyle(nextProps);
+    }
+
     const a = this.__lastRegion;
     const b = nextProps.region;
     if (!a || !b) return;
@@ -461,12 +465,12 @@ class MapView extends React.Component {
   componentDidMount() {
     const { isReady } = this.state;
     if (isReady) {
-      this._updateStyle();
+      this._updateStyle(this.props);
     }
   }
 
-  _updateStyle() {
-    const { customMapStyle } = this.props;
+  _updateStyle(props) {
+    const { customMapStyle } = props;
     this.map.setNativeProps({ customMapStyleString: JSON.stringify(customMapStyle) });
   }
 
@@ -477,7 +481,7 @@ class MapView extends React.Component {
     } else if (initialRegion) {
       this.map.setNativeProps({ initialRegion });
     }
-    this._updateStyle();
+    this._updateStyle(this.props);
     this.setState({ isReady: true }, () => {
       if (onMapReady) onMapReady();
     });


### PR DESCRIPTION
Previously, the library would not pass on the updated style to native Google Maps if a change occurred after onMapReady had fired. The native side doesn't seem to mind this happening, although I did not test extensively.