### PR TITLE
update android build configuration for gradle 3+ in example project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,14 @@
 
 buildscript {
   repositories {
+    // Gradle 4.1 and higher include support for Google's Maven repo using
+    // the google() method. And you need to include this repo to download
+    // Android plugin 3.0.0 or higher.
+    google()
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.3.2'
+    classpath 'com.android.tools.build:gradle:3.1.2'
   }
 }
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -127,8 +127,8 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.51.+'
-    compile 'com.android.support:appcompat-v7:25.3.0'
-    compile 'com.android.support:support-annotations:25.3.0'
-    compile project(':react-native-maps-lib')
+    implementation 'com.facebook.react:react-native:+'
+    implementation 'com.android.support:appcompat-v7:25.3.0'
+    implementation 'com.android.support:support-annotations:25.3.0'
+    implementation project(':react-native-maps-lib')
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
### Does any other open PR do the same thing?
No

### What issue is this PR fixing?
#2296 

It was not possible to just clone the repo, build the lib, and run the example project using gradle or android studio.

### How did you test this PR?
git clone https://github.com/fqborges/react-native-maps.git
cd react-native-maps
git checkout fix-gradle3-build
yarn install
yarn build:android
yarn run:android

**Edit:**
As discussed bellow, the latest version of this lib is already using Gradle 3, which can lead to build issues when integrating with other libs ([react-navigation comes to mind](https://github.com/react-navigation/react-navigation/issues/3097)) caused by how [react-native package the resources assets](https://github.com/facebook/react-native/issues/16906).

An alternative solution would be roll back the changes made on #2096