### PR TITLE
[Proposal] Osmdroid alternative provider for Android

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,14 @@
 
 buildscript {
   repositories {
+    // Gradle 4.1 and higher include support for Google's Maven repo using
+    // the google() method. And you need to include this repo to download
+    // Android plugin 3.0.0 or higher.
+    google()
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.3.2'
+    classpath 'com.android.tools.build:gradle:3.1.2'
   }
 }
 

--- a/example/App.js
+++ b/example/App.js
@@ -8,7 +8,7 @@ import {
   Text,
   Switch,
 } from 'react-native';
-import { PROVIDER_GOOGLE, PROVIDER_DEFAULT } from 'react-native-maps';
+import { PROVIDER_GOOGLE, PROVIDER_OSMDROID, PROVIDER_DEFAULT } from 'react-native-maps';
 import DisplayLatLng from './examples/DisplayLatLng';
 import ViewsAsMarkers from './examples/ViewsAsMarkers';
 import EventListener from './examples/EventListener';
@@ -62,6 +62,7 @@ class App extends React.Component {
     this.state = {
       Component: null,
       useGoogleMaps: ANDROID,
+      useOsmdroid: false,
     };
   }
 
@@ -101,15 +102,36 @@ class App extends React.Component {
     );
   }
 
+  renderOsmdroidSwitch() {
+    return (
+      <View>
+        <Text>Use Osmdroid?</Text>
+        <Switch
+          onValueChange={(value) => this.setState({ useOsmdroid: value })}
+          style={{ marginBottom: 10 }}
+          value={this.state.useOsmdroid}
+        />
+      </View>
+    );
+  }
+
   renderExamples(examples) {
     const {
       Component,
       useGoogleMaps,
+      useOsmdroid,
     } = this.state;
+
+    let provider = PROVIDER_DEFAULT;
+    if (useOsmdroid) {
+      provider = PROVIDER_OSMDROID;
+    } else if (useGoogleMaps) {
+      provider = PROVIDER_GOOGLE;
+    }
 
     return (
       <View style={styles.container}>
-        {Component && <Component provider={useGoogleMaps ? PROVIDER_GOOGLE : PROVIDER_DEFAULT} />}
+        {Component && <Component provider={provider} />}
         {Component && this.renderBackButton()}
         {!Component &&
           <ScrollView
@@ -118,6 +140,7 @@ class App extends React.Component {
             showsVerticalScrollIndicator={false}
           >
             {IOS && this.renderGoogleSwitch()}
+            {ANDROID && this.renderOsmdroidSwitch()}
             {examples.map(example => this.renderExample(example))}
           </ScrollView>
         }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -127,8 +127,8 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.51.+'
-    compile 'com.android.support:appcompat-v7:25.3.0'
-    compile 'com.android.support:support-annotations:25.3.0'
-    compile project(':react-native-maps-lib')
+    implementation 'com.facebook.react:react-native:+'
+    implementation 'com.android.support:appcompat-v7:25.3.0'
+    implementation 'com.android.support:support-annotations:25.3.0'
+    implementation project(':react-native-maps-lib')
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -126,9 +126,14 @@ android {
     }
 }
 
+// todo: check how to define as project properties like our user apps, without messing with
+// root project and lib
+def osmdroidVersion = "6.0.1"
 dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation 'com.android.support:appcompat-v7:25.3.0'
     implementation 'com.android.support:support-annotations:25.3.0'
+
+    implementation "org.osmdroid:osmdroid-android:${osmdroidVersion}"
     implementation project(':react-native-maps-lib')
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ export { Animated, MAP_TYPES, ProviderPropType };
 
 export const PROVIDER_GOOGLE = MapView.PROVIDER_GOOGLE;
 export const PROVIDER_DEFAULT = MapView.PROVIDER_DEFAULT;
+export const PROVIDER_OSMDROID = MapView.PROVIDER_OSMDROID;
 
 export const MarkerAnimated = Marker.Animated;
 export const OverlayAnimated = Overlay.Animated;

--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -6,6 +6,7 @@ def DEFAULT_BUILD_TOOLS_VERSION             = "25.0.3"
 def DEFAULT_TARGET_SDK_VERSION              = 25
 def DEFAULT_GOOGLE_PLAY_SERVICES_VERSION    = "10.2.4"
 def DEFAULT_ANDROID_MAPS_UTILS_VERSION      = "0.5+"
+def DEFAULT_OSMDROID_VERSION                = "6.0.1"
 
 android {
   compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
@@ -42,9 +43,12 @@ android {
 dependencies {
   def googlePlayServicesVersion = rootProject.hasProperty('googlePlayServicesVersion')  ? rootProject.googlePlayServicesVersion : DEFAULT_GOOGLE_PLAY_SERVICES_VERSION
   def androidMapsUtilsVersion   = rootProject.hasProperty('androidMapsUtilsVersion')    ? rootProject.androidMapsUtilsVersion   : DEFAULT_ANDROID_MAPS_UTILS_VERSION
+  def osmdroidVersion = rootProject.hasProperty('osmdroidVersion')  ? rootProject.osmdroidVersion : DEFAULT_OSMDROID_VERSION
 
   compileOnly "com.facebook.react:react-native:+"
   implementation "com.google.android.gms:play-services-base:$googlePlayServicesVersion"
   implementation "com.google.android.gms:play-services-maps:$googlePlayServicesVersion"
   implementation "com.google.maps.android:android-maps-utils:$androidMapsUtilsVersion"
+
+  implementation "org.osmdroid:osmdroid-android:${osmdroidVersion}"
 }

--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -50,5 +50,5 @@ dependencies {
   implementation "com.google.android.gms:play-services-maps:$googlePlayServicesVersion"
   implementation "com.google.maps.android:android-maps-utils:$androidMapsUtilsVersion"
 
-  implementation "org.osmdroid:osmdroid-android:${osmdroidVersion}"
+  compileOnly "org.osmdroid:osmdroid-android:${osmdroidVersion}"
 }

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
@@ -7,6 +7,7 @@ import com.airbnb.android.react.maps.osmdroid.OsmMapManager;
 import com.airbnb.android.react.maps.osmdroid.OsmMapMarkerManager;
 import com.airbnb.android.react.maps.osmdroid.OsmMapPolygonManager;
 import com.airbnb.android.react.maps.osmdroid.OsmMapPolylineManager;
+import com.airbnb.android.react.maps.osmdroid.OsmMapUrlTileManager;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
@@ -63,6 +64,7 @@ public class MapsPackage implements ReactPackage {
     );
 
     if (hasOsmdroidOnClasspath()) {
+      OsmMapUrlTileManager osmUrlTileManager = new OsmMapUrlTileManager();
       OsmMapCalloutManager osmCalloutManager = new OsmMapCalloutManager();
       OsmMapMarkerManager osmMarkerManager = new OsmMapMarkerManager();
       OsmMapPolylineManager osmPolylineManager = new OsmMapPolylineManager(reactContext);
@@ -71,6 +73,7 @@ public class MapsPackage implements ReactPackage {
 
       List<ViewManager> managers = new ArrayList<>(airMapManagers);
       managers.addAll(Arrays.<ViewManager>asList(
+          osmUrlTileManager,
           osmCalloutManager,
           osmMarkerManager,
           osmPolylineManager,

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
@@ -2,6 +2,11 @@ package com.airbnb.android.react.maps;
 
 import android.app.Activity;
 
+import com.airbnb.android.react.maps.osmdroid.OsmMapCalloutManager;
+import com.airbnb.android.react.maps.osmdroid.OsmMapManager;
+import com.airbnb.android.react.maps.osmdroid.OsmMapMarkerManager;
+import com.airbnb.android.react.maps.osmdroid.OsmMapPolygonManager;
+import com.airbnb.android.react.maps.osmdroid.OsmMapPolylineManager;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
@@ -42,6 +47,12 @@ public class MapsPackage implements ReactPackage {
     AirMapLocalTileManager localTileManager = new AirMapLocalTileManager(reactContext);
     AirMapOverlayManager overlayManager = new AirMapOverlayManager(reactContext);
 
+    OsmMapCalloutManager osmCalloutManager = new OsmMapCalloutManager();
+    OsmMapMarkerManager osmMarkerManager = new OsmMapMarkerManager();
+    OsmMapPolylineManager osmPolylineManager = new OsmMapPolylineManager(reactContext);
+    OsmMapPolygonManager osmPolygonManager = new OsmMapPolygonManager(reactContext);
+    OsmMapManager osmMapManager = new OsmMapManager(reactContext);
+
     return Arrays.<ViewManager>asList(
         calloutManager,
         annotationManager,
@@ -52,7 +63,12 @@ public class MapsPackage implements ReactPackage {
         mapLiteManager,
         urlTileManager,
         localTileManager,
-        overlayManager
+        overlayManager,
+        osmCalloutManager,
+        osmMarkerManager,
+        osmPolylineManager,
+        osmPolygonManager,
+        osmMapManager
     );
   }
 }

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
@@ -13,6 +13,8 @@ import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
 
+import java.lang.reflect.Array;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -47,13 +49,7 @@ public class MapsPackage implements ReactPackage {
     AirMapLocalTileManager localTileManager = new AirMapLocalTileManager(reactContext);
     AirMapOverlayManager overlayManager = new AirMapOverlayManager(reactContext);
 
-    OsmMapCalloutManager osmCalloutManager = new OsmMapCalloutManager();
-    OsmMapMarkerManager osmMarkerManager = new OsmMapMarkerManager();
-    OsmMapPolylineManager osmPolylineManager = new OsmMapPolylineManager(reactContext);
-    OsmMapPolygonManager osmPolygonManager = new OsmMapPolygonManager(reactContext);
-    OsmMapManager osmMapManager = new OsmMapManager(reactContext);
-
-    return Arrays.<ViewManager>asList(
+    List<ViewManager> airMapManagers = Arrays.<ViewManager>asList(
         calloutManager,
         annotationManager,
         polylineManager,
@@ -63,12 +59,37 @@ public class MapsPackage implements ReactPackage {
         mapLiteManager,
         urlTileManager,
         localTileManager,
-        overlayManager,
-        osmCalloutManager,
-        osmMarkerManager,
-        osmPolylineManager,
-        osmPolygonManager,
-        osmMapManager
+        overlayManager
     );
+
+    if (hasOsmdroidOnClasspath()) {
+      OsmMapCalloutManager osmCalloutManager = new OsmMapCalloutManager();
+      OsmMapMarkerManager osmMarkerManager = new OsmMapMarkerManager();
+      OsmMapPolylineManager osmPolylineManager = new OsmMapPolylineManager(reactContext);
+      OsmMapPolygonManager osmPolygonManager = new OsmMapPolygonManager(reactContext);
+      OsmMapManager osmMapManager = new OsmMapManager(reactContext);
+
+      List<ViewManager> managers = new ArrayList<>(airMapManagers);
+      managers.addAll(Arrays.<ViewManager>asList(
+          osmCalloutManager,
+          osmMarkerManager,
+          osmPolylineManager,
+          osmPolygonManager,
+          osmMapManager
+      ));
+      return managers;
+    }
+
+    return airMapManagers;
+  }
+
+  private boolean hasOsmdroidOnClasspath() {
+    try {
+      Class.forName("org.osmdroid.views.MapView");
+      return true;
+    } catch (ClassNotFoundException ex) {
+      ex.printStackTrace();
+    }
+    return false;
   }
 }

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapCallout.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapCallout.java
@@ -1,0 +1,22 @@
+package com.airbnb.android.react.maps.osmdroid;
+
+import android.content.Context;
+import com.facebook.react.views.view.ReactViewGroup;
+
+public class OsmMapCallout extends ReactViewGroup {
+  private boolean tooltip = false;
+  public int width;
+  public int height;
+
+  public OsmMapCallout(Context context) {
+    super(context);
+  }
+
+  public void setTooltip(boolean tooltip) {
+    this.tooltip = tooltip;
+  }
+
+  public boolean getTooltip() {
+    return this.tooltip;
+  }
+}

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapCalloutManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapCalloutManager.java
@@ -1,0 +1,57 @@
+package com.airbnb.android.react.maps.osmdroid;
+
+import com.airbnb.android.react.maps.SizeReportingShadowNode;
+import com.facebook.react.common.MapBuilder;
+import com.facebook.react.uimanager.LayoutShadowNode;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.ViewGroupManager;
+import com.facebook.react.uimanager.annotations.ReactProp;
+
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+public class OsmMapCalloutManager extends ViewGroupManager<OsmMapCallout> {
+
+    @Override
+    public String getName() {
+        return "OsmMapCallout";
+    }
+
+    @Override
+    public OsmMapCallout createViewInstance(ThemedReactContext context) {
+        return new OsmMapCallout(context);
+    }
+
+    @ReactProp(name = "tooltip", defaultBoolean = false)
+    public void setTooltip(OsmMapCallout view, boolean tooltip) {
+        view.setTooltip(tooltip);
+    }
+
+    @Override
+    @Nullable
+    public Map getExportedCustomDirectEventTypeConstants() {
+        return MapBuilder.of("onPress", MapBuilder.of("registrationName", "onPress"));
+    }
+
+    @Override
+    public LayoutShadowNode createShadowNodeInstance() {
+        // we use a custom shadow node that emits the width/height of the view
+        // after layout with the updateExtraData method. Without this, we can't generate
+        // a bitmap of the appropriate width/height of the rendered view.
+        return new SizeReportingShadowNode();
+    }
+
+    @Override
+    public void updateExtraData(OsmMapCallout view, Object extraData) {
+        // This method is called from the shadow node with the width/height of the rendered
+        // marker view.
+        //noinspection unchecked
+        Map<String, Float> data = (Map<String, Float>) extraData;
+        float width = data.get("width");
+        float height = data.get("height");
+        view.width = (int) width;
+        view.height = (int) height;
+    }
+
+}

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapFeature.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapFeature.java
@@ -1,0 +1,19 @@
+package com.airbnb.android.react.maps.osmdroid;
+
+import android.content.Context;
+
+import com.facebook.react.views.view.ReactViewGroup;
+
+import org.osmdroid.views.MapView;
+
+public abstract class OsmMapFeature extends ReactViewGroup {
+  public OsmMapFeature(Context context) {
+    super(context);
+  }
+
+  public abstract void addToMap(MapView map);
+
+  public abstract void removeFromMap(MapView map);
+
+  public abstract Object getFeature();
+}

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapManager.java
@@ -1,0 +1,343 @@
+package com.airbnb.android.react.maps.osmdroid;
+
+import android.preference.PreferenceManager;
+import android.view.View;
+
+import com.airbnb.android.react.maps.SizeReportingShadowNode;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.common.MapBuilder;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.facebook.react.uimanager.LayoutShadowNode;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.ViewGroupManager;
+import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+
+import org.osmdroid.config.Configuration;
+import org.osmdroid.util.BoundingBox;
+import org.osmdroid.util.GeoPoint;
+
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+public class OsmMapManager extends ViewGroupManager<OsmMapView> {
+
+    private static final String REACT_CLASS = "OsmMap";
+    private static final int ANIMATE_TO_REGION = 1;
+    private static final int ANIMATE_TO_COORDINATE = 2;
+    private static final int ANIMATE_TO_VIEWING_ANGLE = 3;
+    private static final int ANIMATE_TO_BEARING = 4;
+    private static final int FIT_TO_ELEMENTS = 5;
+    private static final int FIT_TO_SUPPLIED_MARKERS = 6;
+    private static final int FIT_TO_COORDINATES = 7;
+
+    private final ReactApplicationContext appContext;
+
+    public OsmMapManager(ReactApplicationContext context) {
+        this.appContext = context;
+
+        final String packageName = context.getApplicationContext().getApplicationInfo().packageName;
+        Configuration.getInstance().load(context, PreferenceManager.getDefaultSharedPreferences(context));
+        Configuration.getInstance().setUserAgentValue(packageName);
+    }
+
+    void invalidateNode(final OsmMapView view) {
+        // to force refresh when adding/updating a callout
+        appContext.runOnNativeModulesQueueThread(new Runnable() {
+            @Override
+            public void run() {
+                // TODO: very hacky way of forcing layout, discover how to replace (or avoid) this.
+                int width = view.getWidth();
+                int height = view.getHeight();
+                UIManagerModule uiManagerModule = appContext.getNativeModule(UIManagerModule.class);
+                uiManagerModule.updateNodeSize(view.getId(), width, height + 1);
+                uiManagerModule.updateNodeSize(view.getId(), width, height);
+            }
+        });
+    }
+
+    @Override
+    public String getName() {
+        return REACT_CLASS;
+    }
+
+    @Override
+    protected OsmMapView createViewInstance(ThemedReactContext context) {
+        OsmMapView view = new OsmMapView(context, this.appContext, this);
+        view.setBuiltInZoomControls(false);
+        view.setZoomEnabled(true);
+        view.setRotateEnabled(true);
+        view.setScrollEnabled(true);
+        return view;
+    }
+
+    private void emitMapError(ThemedReactContext context, String message, String type) {
+        WritableMap error = Arguments.createMap();
+        error.putString("message", message);
+        error.putString("type", type);
+
+        context
+                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                .emit("onError", error);
+    }
+
+    @ReactProp(name = "region")
+    public void setRegion(OsmMapView view, ReadableMap region) {
+        view.setRegion(region);
+    }
+
+    @ReactProp(name = "initialRegion")
+    public void setInitialRegion(OsmMapView view, ReadableMap initialRegion) {
+        view.setInitialRegion(initialRegion);
+    }
+//
+//  @ReactProp(name = "mapType")
+//  public void setMapType(AirMapView view, @Nullable String mapType) {
+//    int typeId = MAP_TYPES.get(mapType);
+//    view.map.setMapType(typeId);
+//  }
+//
+//  @ReactProp(name = "customMapStyleString")
+//  public void setMapStyle(AirMapView view, @Nullable String customMapStyleString) {
+//    view.map.setMapStyle(new MapStyleOptions(customMapStyleString));
+//  }
+//
+//  @ReactProp(name = "showsUserLocation", defaultBoolean = false)
+//  public void setShowsUserLocation(AirMapView view, boolean showUserLocation) {
+//    view.setShowsUserLocation(showUserLocation);
+//  }
+//
+//  @ReactProp(name = "showsMyLocationButton", defaultBoolean = true)
+//  public void setShowsMyLocationButton(AirMapView view, boolean showMyLocationButton) {
+//    view.setShowsMyLocationButton(showMyLocationButton);
+//  }
+//
+//  @ReactProp(name = "toolbarEnabled", defaultBoolean = true)
+//  public void setToolbarEnabled(AirMapView view, boolean toolbarEnabled) {
+//    view.setToolbarEnabled(toolbarEnabled);
+//  }
+
+    // This is a private prop to improve performance of panDrag by disabling it when the callback
+    // is not set
+    @ReactProp(name = "handlePanDrag", defaultBoolean = false)
+    public void setHandlePanDrag(OsmMapView view, boolean handlePanDrag) {
+        view.setHandlePanDrag(handlePanDrag);
+    }
+
+//  @ReactProp(name = "showsTraffic", defaultBoolean = false)
+//  public void setShowTraffic(AirMapView view, boolean showTraffic) {
+//    view.map.setTrafficEnabled(showTraffic);
+//  }
+//
+//  @ReactProp(name = "showsBuildings", defaultBoolean = false)
+//  public void setShowBuildings(AirMapView view, boolean showBuildings) {
+//    view.map.setBuildingsEnabled(showBuildings);
+//  }
+//
+//  @ReactProp(name = "showsIndoors", defaultBoolean = false)
+//  public void setShowIndoors(AirMapView view, boolean showIndoors) {
+//    view.map.setIndoorEnabled(showIndoors);
+//  }
+//
+//  @ReactProp(name = "showsIndoorLevelPicker", defaultBoolean = false)
+//  public void setShowsIndoorLevelPicker(AirMapView view, boolean showsIndoorLevelPicker) {
+//    view.map.getUiSettings().setIndoorLevelPickerEnabled(showsIndoorLevelPicker);
+//  }
+//
+//  @ReactProp(name = "showsCompass", defaultBoolean = false)
+//  public void setShowsCompass(AirMapView view, boolean showsCompass) {
+//  }
+
+    @ReactProp(name = "scrollEnabled", defaultBoolean = false)
+    public void setScrollEnabled(OsmMapView view, boolean scrollEnabled) {
+        view.setScrollEnabled(scrollEnabled);
+    }
+
+    @ReactProp(name = "zoomEnabled", defaultBoolean = false)
+    public void setZoomEnabled(OsmMapView view, boolean zoomEnabled) {
+        view.setZoomEnabled(zoomEnabled);
+    }
+
+    @ReactProp(name = "rotateEnabled", defaultBoolean = false)
+    public void setRotateEnabled(OsmMapView view, boolean rotateEnabled) {
+        view.setRotateEnabled(rotateEnabled);
+    }
+
+//  @ReactProp(name = "cacheEnabled", defaultBoolean = false)
+//  public void setCacheEnabled(AirMapView view, boolean cacheEnabled) {
+//    view.setCacheEnabled(cacheEnabled);
+//  }
+//
+//  @ReactProp(name = "loadingEnabled", defaultBoolean = false)
+//  public void setLoadingEnabled(AirMapView view, boolean loadingEnabled) {
+//    view.enableMapLoading(loadingEnabled);
+//  }
+//
+//  @ReactProp(name = "moveOnMarkerPress", defaultBoolean = true)
+//  public void setMoveOnMarkerPress(AirMapView view, boolean moveOnPress) {
+//    view.setMoveOnMarkerPress(moveOnPress);
+//  }
+//
+//  @ReactProp(name = "loadingBackgroundColor", customType = "Color")
+//  public void setLoadingBackgroundColor(AirMapView view, @Nullable Integer
+// loadingBackgroundColor) {
+//    view.setLoadingBackgroundColor(loadingBackgroundColor);
+//  }
+//
+//  @ReactProp(name = "loadingIndicatorColor", customType = "Color")
+//  public void setLoadingIndicatorColor(AirMapView view, @Nullable Integer loadingIndicatorColor) {
+//    view.setLoadingIndicatorColor(loadingIndicatorColor);
+//  }
+
+    @ReactProp(name = "minZoomLevel")
+    public void setMinZoomLevel(OsmMapView view, float minZoomLevel) {
+        view.setMinZoomLevel((double) minZoomLevel);
+    }
+
+    @ReactProp(name = "maxZoomLevel")
+    public void setMaxZoomLevel(OsmMapView view, float maxZoomLevel) {
+        view.setMaxZoomLevel((double) maxZoomLevel);
+    }
+
+    @Override
+    public void receiveCommand(OsmMapView view, int commandId, @Nullable ReadableArray args) {
+        Integer duration;
+        Double lat;
+        Double lng;
+        Double lngDelta;
+        Double latDelta;
+        float bearing;
+        ReadableMap region;
+
+        switch (commandId) {
+            case ANIMATE_TO_REGION:
+                region = args.getMap(0);
+                duration = args.getInt(1);
+                lng = region.getDouble("longitude");
+                lat = region.getDouble("latitude");
+                lngDelta = region.getDouble("longitudeDelta");
+                latDelta = region.getDouble("latitudeDelta");
+                BoundingBox bounds = new BoundingBox(
+                        lat + latDelta / 2, lng + lngDelta / 2, // northeast
+                        lat - latDelta / 2, lng - lngDelta / 2 // southwest
+                );
+                view.animateToRegion(bounds, duration);
+                break;
+
+            case ANIMATE_TO_COORDINATE:
+                region = args.getMap(0);
+                duration = args.getInt(1);
+                lng = region.getDouble("longitude");
+                lat = region.getDouble("latitude");
+                view.animateToCoordinate(new GeoPoint(lat, lng), duration);
+                break;
+
+            case ANIMATE_TO_VIEWING_ANGLE:
+                // not supported!
+                break;
+
+            case ANIMATE_TO_BEARING:
+                bearing = (float) args.getDouble(0);
+                duration = args.getInt(1);
+                view.animateToBearing(bearing, duration);
+                break;
+
+            case FIT_TO_ELEMENTS:
+                view.fitToElements(args.getBoolean(0));
+                break;
+
+            case FIT_TO_SUPPLIED_MARKERS:
+                view.fitToSuppliedMarkers(args.getArray(0), args.getBoolean(1));
+                break;
+            case FIT_TO_COORDINATES:
+                view.fitToCoordinates(args.getArray(0), args.getMap(1), args.getBoolean(2));
+                break;
+        }
+    }
+
+    @Override
+    @Nullable
+    public Map getExportedCustomDirectEventTypeConstants() {
+        Map<String, Map<String, String>> map = MapBuilder.of(
+                "onMapReady", MapBuilder.of("registrationName", "onMapReady"),
+                "onPress", MapBuilder.of("registrationName", "onPress"),
+                "onLongPress", MapBuilder.of("registrationName", "onLongPress"),
+                "onMarkerPress", MapBuilder.of("registrationName", "onMarkerPress"),
+                "onMarkerSelect", MapBuilder.of("registrationName", "onMarkerSelect"),
+                "onMarkerDeselect", MapBuilder.of("registrationName", "onMarkerDeselect"),
+                "onCalloutPress", MapBuilder.of("registrationName", "onCalloutPress")
+        );
+
+        map.putAll(MapBuilder.of(
+                "onMarkerDragStart", MapBuilder.of("registrationName", "onMarkerDragStart"),
+                "onMarkerDrag", MapBuilder.of("registrationName", "onMarkerDrag"),
+                "onMarkerDragEnd", MapBuilder.of("registrationName", "onMarkerDragEnd"),
+                "onPanDrag", MapBuilder.of("registrationName", "onPanDrag")
+        ));
+
+        return map;
+    }
+
+    @Override
+    @Nullable
+    public Map<String, Integer> getCommandsMap() {
+        return MapBuilder.of(
+                "animateToRegion", ANIMATE_TO_REGION,
+                "animateToCoordinate", ANIMATE_TO_COORDINATE,
+                "animateToViewingAngle", ANIMATE_TO_VIEWING_ANGLE,
+                "animateToBearing", ANIMATE_TO_BEARING,
+                "fitToElements", FIT_TO_ELEMENTS,
+                "fitToSuppliedMarkers", FIT_TO_SUPPLIED_MARKERS,
+                "fitToCoordinates", FIT_TO_COORDINATES
+        );
+    }
+
+    @Override
+    public LayoutShadowNode createShadowNodeInstance() {
+        // A custom shadow node is needed in order to pass back the width/height of the map to the
+        // view manager so that it can start applying camera moves with bounds.
+        return new SizeReportingShadowNode();
+    }
+
+    @Override
+    public void addView(OsmMapView parent, View child, int index) {
+        parent.addFeature(child, index);
+    }
+
+    @Override
+    public int getChildCount(OsmMapView view) {
+        return view.getFeatureCount();
+    }
+
+    @Override
+    public View getChildAt(OsmMapView view, int index) {
+        return view.getFeatureAt(index);
+    }
+
+    @Override
+    public void removeViewAt(OsmMapView parent, int index) {
+        parent.removeFeatureAt(index);
+    }
+
+    @Override
+    public void updateExtraData(OsmMapView view, Object extraData) {
+        view.updateExtraData(extraData);
+    }
+
+    void pushEvent(ThemedReactContext context, View view, String name, WritableMap data) {
+        context.getJSModule(RCTEventEmitter.class)
+                .receiveEvent(view.getId(), name, data);
+    }
+
+    @Override
+    public void onDropViewInstance(OsmMapView view) {
+        super.onDropViewInstance(view);
+    }
+
+}

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapManager.java
@@ -70,7 +70,6 @@ public class OsmMapManager extends ViewGroupManager<OsmMapView> {
     @Override
     protected OsmMapView createViewInstance(ThemedReactContext context) {
         OsmMapView view = new OsmMapView(context, this.appContext, this);
-        view.setBuiltInZoomControls(false);
         view.setZoomEnabled(true);
         view.setRotateEnabled(true);
         view.setScrollEnabled(true);
@@ -338,6 +337,7 @@ public class OsmMapManager extends ViewGroupManager<OsmMapView> {
     @Override
     public void onDropViewInstance(OsmMapView view) {
         super.onDropViewInstance(view);
+        view.doDestroy();
     }
 
 }

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapManager.java
@@ -177,12 +177,12 @@ public class OsmMapManager extends ViewGroupManager<OsmMapView> {
 //  public void setLoadingEnabled(AirMapView view, boolean loadingEnabled) {
 //    view.enableMapLoading(loadingEnabled);
 //  }
-//
-//  @ReactProp(name = "moveOnMarkerPress", defaultBoolean = true)
-//  public void setMoveOnMarkerPress(AirMapView view, boolean moveOnPress) {
-//    view.setMoveOnMarkerPress(moveOnPress);
-//  }
-//
+
+  @ReactProp(name = "moveOnMarkerPress", defaultBoolean = true)
+  public void setMoveOnMarkerPress(OsmMapView view, boolean moveOnPress) {
+    view.setMoveOnMarkerPress(moveOnPress);
+  }
+
 //  @ReactProp(name = "loadingBackgroundColor", customType = "Color")
 //  public void setLoadingBackgroundColor(AirMapView view, @Nullable Integer
 // loadingBackgroundColor) {

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapMarker.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapMarker.java
@@ -60,10 +60,9 @@ public class OsmMapMarker extends OsmMapFeature {
     private float anchorY;
 
     private OsmMapCallout calloutView;
-    private final Context context;
 
     private float markerHue = 0.0f; // should be between 0 and 360
-    private Drawable iconBitmapDescriptor;
+    private Drawable iconBitmapDrawable;
     private Bitmap iconBitmap;
 
     private float rotation = 0.0f;
@@ -99,7 +98,7 @@ public class OsmMapMarker extends OsmMapFeature {
                                 if (bitmap != null) {
                                     bitmap = bitmap.copy(Bitmap.Config.ARGB_8888, true);
                                     iconBitmap = bitmap;
-                                    iconBitmapDescriptor = new BitmapDrawable(getResources(), bitmap);
+                                    iconBitmapDrawable = new BitmapDrawable(getResources(), bitmap);
                                 }
                             }
                         }
@@ -115,7 +114,6 @@ public class OsmMapMarker extends OsmMapFeature {
 
     public OsmMapMarker(Context context) {
         super(context);
-        this.context = context;
         logoHolder = DraweeHolder.create(createDraweeHierarchy(), context);
         logoHolder.onAttach();
     }
@@ -227,7 +225,7 @@ public class OsmMapMarker extends OsmMapFeature {
 
     public void setImage(String uri) {
         if (uri == null) {
-            iconBitmapDescriptor = null;
+            iconBitmapDrawable = null;
             update();
         } else if (uri.startsWith("http://") || uri.startsWith("https://") ||
                 uri.startsWith("file://")) {
@@ -244,8 +242,8 @@ public class OsmMapMarker extends OsmMapFeature {
                     .build();
             logoHolder.setController(controller);
         } else {
-            iconBitmapDescriptor = getBitmapDescriptorByName(uri);
-            if (iconBitmapDescriptor != null) {
+            iconBitmapDrawable = getBitmapDrawableByName(uri);
+            if (iconBitmapDrawable != null) {
                 iconBitmap = BitmapFactory.decodeResource(getResources(), getDrawableResourceByName(uri));
             }
             update();
@@ -295,7 +293,7 @@ public class OsmMapMarker extends OsmMapFeature {
     private Drawable getIcon() {
         if (hasCustomMarkerView) {
             // creating a bitmap from an arbitrary view
-            if (iconBitmapDescriptor != null) {
+            if (iconBitmapDrawable != null) {
                 Bitmap viewBitmap = createDrawable();
                 int width = Math.max(iconBitmap.getWidth(), viewBitmap.getWidth());
                 int height = Math.max(iconBitmap.getHeight(), viewBitmap.getHeight());
@@ -307,9 +305,9 @@ public class OsmMapMarker extends OsmMapFeature {
             } else {
                 return new BitmapDrawable(getResources(), createDrawable());
             }
-        } else if (iconBitmapDescriptor != null) {
+        } else if (iconBitmapDrawable != null) {
             // use local image as a marker
-            return iconBitmapDescriptor;
+            return iconBitmapDrawable;
         } else {
             // render the default marker pin
             // return BitmapDescriptorFactory.defaultMarker(this.markerHue);
@@ -426,7 +424,7 @@ public class OsmMapMarker extends OsmMapFeature {
                 getContext().getPackageName());
     }
 
-    private Drawable getBitmapDescriptorByName(String name) {
+    private Drawable getBitmapDrawableByName(String name) {
         return getResources().getDrawable(getDrawableResourceByName(name));
     }
 

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapMarker.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapMarker.java
@@ -1,0 +1,485 @@
+package com.airbnb.android.react.maps.osmdroid;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Canvas;
+import android.graphics.Rect;
+import android.graphics.drawable.Animatable;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
+import android.net.Uri;
+import android.view.MotionEvent;
+import android.view.View;
+import android.widget.LinearLayout;
+
+import com.facebook.common.references.CloseableReference;
+import com.facebook.datasource.DataSource;
+import com.facebook.drawee.backends.pipeline.Fresco;
+import com.facebook.drawee.controller.BaseControllerListener;
+import com.facebook.drawee.controller.ControllerListener;
+import com.facebook.drawee.drawable.ScalingUtils;
+import com.facebook.drawee.generic.GenericDraweeHierarchy;
+import com.facebook.drawee.generic.GenericDraweeHierarchyBuilder;
+import com.facebook.drawee.interfaces.DraweeController;
+import com.facebook.drawee.view.DraweeHolder;
+import com.facebook.imagepipeline.core.ImagePipeline;
+import com.facebook.imagepipeline.image.CloseableImage;
+import com.facebook.imagepipeline.image.CloseableStaticBitmap;
+import com.facebook.imagepipeline.image.ImageInfo;
+import com.facebook.imagepipeline.request.ImageRequest;
+import com.facebook.imagepipeline.request.ImageRequestBuilder;
+import com.facebook.react.bridge.ReadableMap;
+
+import org.osmdroid.util.GeoPoint;
+import org.osmdroid.views.MapView;
+import org.osmdroid.views.overlay.Marker;
+import org.osmdroid.views.overlay.infowindow.InfoWindow;
+
+import javax.annotation.Nullable;
+
+import static android.view.KeyEvent.ACTION_UP;
+
+public class OsmMapMarker extends OsmMapFeature {
+
+    private Marker marker;
+    private MapView mapView;
+    private InfoWindow defaultInfoWindow;
+    private InfoWindow customInfoWindowCache;
+    private Drawable defaultBubbleDrawable;
+    private int width;
+    private int height;
+    private String identifier;
+
+    private GeoPoint position;
+    private String title;
+    private String snippet;
+
+    private boolean anchorIsSet;
+    private float anchorX;
+    private float anchorY;
+
+    private OsmMapCallout calloutView;
+    private final Context context;
+
+    private float markerHue = 0.0f; // should be between 0 and 360
+    private Drawable iconBitmapDescriptor;
+    private Bitmap iconBitmap;
+
+    private float rotation = 0.0f;
+    private boolean flat = false;
+    private boolean draggable = false;
+    private int zIndex = 0;
+    private float opacity = 1.0f;
+
+    private float calloutAnchorX;
+    private float calloutAnchorY;
+    private boolean calloutAnchorIsSet;
+
+    private boolean hasCustomMarkerView = false;
+    private OnCalloutPressListener onCalloutPressListener;
+
+    private final DraweeHolder<?> logoHolder;
+    private DataSource<CloseableReference<CloseableImage>> dataSource;
+    private final ControllerListener<ImageInfo> mLogoControllerListener =
+            new BaseControllerListener<ImageInfo>() {
+                @Override
+                public void onFinalImageSet(
+                        String id,
+                        @Nullable final ImageInfo imageInfo,
+                        @Nullable Animatable animatable) {
+                    CloseableReference<CloseableImage> imageReference = null;
+                    try {
+                        imageReference = dataSource.getResult();
+                        if (imageReference != null) {
+                            CloseableImage image = imageReference.get();
+                            if (image != null && image instanceof CloseableStaticBitmap) {
+                                CloseableStaticBitmap closeableStaticBitmap = (CloseableStaticBitmap) image;
+                                Bitmap bitmap = closeableStaticBitmap.getUnderlyingBitmap();
+                                if (bitmap != null) {
+                                    bitmap = bitmap.copy(Bitmap.Config.ARGB_8888, true);
+                                    iconBitmap = bitmap;
+                                    iconBitmapDescriptor = new BitmapDrawable(getResources(), bitmap);
+                                }
+                            }
+                        }
+                    } finally {
+                        dataSource.close();
+                        if (imageReference != null) {
+                            CloseableReference.closeSafely(imageReference);
+                        }
+                    }
+                    update();
+                }
+            };
+
+    public OsmMapMarker(Context context) {
+        super(context);
+        this.context = context;
+        logoHolder = DraweeHolder.create(createDraweeHierarchy(), context);
+        logoHolder.onAttach();
+    }
+
+    private GenericDraweeHierarchy createDraweeHierarchy() {
+        return new GenericDraweeHierarchyBuilder(getResources())
+                .setActualImageScaleType(ScalingUtils.ScaleType.FIT_CENTER)
+                .setFadeDuration(0)
+                .build();
+    }
+
+    public void setCoordinate(ReadableMap coordinate) {
+        position = new GeoPoint(coordinate.getDouble("latitude"), coordinate.getDouble("longitude"));
+        if (marker != null) {
+            marker.setPosition(position);
+        }
+        update();
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+        update();
+    }
+
+    public String getIdentifier() {
+        return this.identifier;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+        if (marker != null) {
+            marker.setTitle(title);
+        }
+        update();
+    }
+
+    public void setSnippet(String snippet) {
+        this.snippet = snippet;
+        if (marker != null) {
+            marker.setSnippet(snippet);
+        }
+        update();
+    }
+
+    public void setRotation(float rotation) {
+        this.rotation = rotation;
+        if (marker != null) {
+            marker.setRotation(rotation);
+        }
+        update();
+    }
+
+    public void setFlat(boolean flat) {
+        this.flat = flat;
+        if (marker != null) {
+            marker.setFlat(flat);
+        }
+        update();
+    }
+
+    public void setDraggable(boolean draggable) {
+        this.draggable = draggable;
+        if (marker != null) {
+            marker.setDraggable(draggable);
+        }
+        update();
+    }
+
+//  public void setZIndex(int zIndex) {
+//    this.zIndex = zIndex;
+//    if (marker != null) {
+//      marker.setZIndex(zIndex);
+//    }
+//    update();
+//  }
+
+    public void setOpacity(float opacity) {
+        this.opacity = opacity;
+        if (marker != null) {
+            marker.setAlpha(opacity);
+        }
+        update();
+    }
+
+    public void setMarkerHue(float markerHue) {
+        this.markerHue = markerHue;
+        update();
+    }
+
+    public void setAnchor(double x, double y) {
+        anchorIsSet = true;
+        anchorX = (float) x;
+        anchorY = (float) y;
+        if (marker != null) {
+            marker.setAnchor(anchorX, anchorY);
+        }
+        update();
+    }
+
+    public void setCalloutAnchor(double x, double y) {
+        calloutAnchorIsSet = true;
+        calloutAnchorX = (float) x;
+        calloutAnchorY = (float) y;
+        if (marker != null) {
+            marker.setInfoWindowAnchor(calloutAnchorX, calloutAnchorY);
+        }
+        update();
+    }
+
+    public void setImage(String uri) {
+        if (uri == null) {
+            iconBitmapDescriptor = null;
+            update();
+        } else if (uri.startsWith("http://") || uri.startsWith("https://") ||
+                uri.startsWith("file://")) {
+            ImageRequest imageRequest = ImageRequestBuilder
+                    .newBuilderWithSource(Uri.parse(uri))
+                    .build();
+
+            ImagePipeline imagePipeline = Fresco.getImagePipeline();
+            dataSource = imagePipeline.fetchDecodedImage(imageRequest, this);
+            DraweeController controller = Fresco.newDraweeControllerBuilder()
+                    .setImageRequest(imageRequest)
+                    .setControllerListener(mLogoControllerListener)
+                    .setOldController(logoHolder.getController())
+                    .build();
+            logoHolder.setController(controller);
+        } else {
+            iconBitmapDescriptor = getBitmapDescriptorByName(uri);
+            if (iconBitmapDescriptor != null) {
+                iconBitmap = BitmapFactory.decodeResource(getResources(), getDrawableResourceByName(uri));
+            }
+            update();
+        }
+    }
+
+    @Override
+    public void addView(View child, int index) {
+        super.addView(child, index);
+        // if children are added, it means we are rendering a custom marker
+        if (!(child instanceof OsmMapCallout)) {
+            hasCustomMarkerView = true;
+        }
+        update();
+    }
+
+    @Override
+    public Object getFeature() {
+        return marker;
+    }
+
+    @Override
+    public void addToMap(MapView map) {
+        marker = new Marker(map);
+        defaultInfoWindow = marker.getInfoWindow();
+        defaultInfoWindow.getView().setOnTouchListener(OsmMapMarker.this.infoWindowTouched);
+        mapView = map;
+        initProperties(marker);
+        map.getOverlays().add(marker);
+    }
+
+    @Override
+    public void removeFromMap(MapView map) {
+        if (marker == null) return;
+        marker.remove(map);
+        cleanup();
+    }
+
+    public void cleanup() {
+        marker = null;
+        mapView = null;
+        defaultInfoWindow = null;
+        customInfoWindowCache = null;
+        defaultBubbleDrawable = null;
+    }
+
+    private Drawable getIcon() {
+        if (hasCustomMarkerView) {
+            // creating a bitmap from an arbitrary view
+            if (iconBitmapDescriptor != null) {
+                Bitmap viewBitmap = createDrawable();
+                int width = Math.max(iconBitmap.getWidth(), viewBitmap.getWidth());
+                int height = Math.max(iconBitmap.getHeight(), viewBitmap.getHeight());
+                Bitmap combinedBitmap = Bitmap.createBitmap(width, height, iconBitmap.getConfig());
+                Canvas canvas = new Canvas(combinedBitmap);
+                canvas.drawBitmap(iconBitmap, 0, 0, null);
+                canvas.drawBitmap(viewBitmap, 0, 0, null);
+                return new BitmapDrawable(getResources(), combinedBitmap);
+            } else {
+                return new BitmapDrawable(getResources(), createDrawable());
+            }
+        } else if (iconBitmapDescriptor != null) {
+            // use local image as a marker
+            return iconBitmapDescriptor;
+        } else {
+            // render the default marker pin
+            // return BitmapDescriptorFactory.defaultMarker(this.markerHue);
+            return null;
+        }
+    }
+
+    private void initProperties(Marker marker) {
+        marker.setPosition(position);
+        if (anchorIsSet) marker.setAnchor(anchorX, anchorY);
+        if (calloutAnchorIsSet) marker.setInfoWindowAnchor(calloutAnchorX, calloutAnchorY);
+        marker.setInfoWindow(getInfoWindow());
+        marker.setTitle(title);
+        marker.setSnippet(snippet);
+        marker.setRotation(rotation);
+        marker.setFlat(flat);
+        marker.setDraggable(draggable);
+        // TODO: options.zIndex(zIndex);
+        marker.setAlpha(opacity);
+        marker.setIcon(getIcon());
+    }
+
+    public void update() {
+        if (marker == null) {
+            return;
+        }
+
+        marker.setInfoWindow(getInfoWindow());
+
+        marker.setIcon(getIcon());
+
+        if (anchorIsSet) {
+            marker.setAnchor(anchorX, anchorY);
+        } else {
+            marker.setAnchor(0.5f, 1.0f);
+        }
+
+        if (calloutAnchorIsSet) {
+            marker.setInfoWindowAnchor(calloutAnchorX, calloutAnchorY);
+        } else {
+            marker.setInfoWindowAnchor(0.5f, 0);
+        }
+
+        mapView.invalidate();
+    }
+
+    public void update(int width, int height) {
+        this.width = width;
+        this.height = height;
+        update();
+    }
+
+    @Nullable
+    private InfoWindow getInfoWindow() {
+        InfoWindow customInfoWindow = getCustomInfoWindow();
+        if (customInfoWindow != null)
+            return customInfoWindow;
+        if (title != null || snippet != null)
+            return defaultInfoWindow;
+        return null;
+    }
+
+    private Bitmap createDrawable() {
+        int width = this.width <= 0 ? 100 : this.width;
+        int height = this.height <= 0 ? 100 : this.height;
+        this.buildDrawingCache();
+        Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+
+        Canvas canvas = new Canvas(bitmap);
+        this.draw(canvas);
+
+        return bitmap;
+    }
+
+    public void setCalloutView(OsmMapCallout view) {
+        this.calloutView = view;
+    }
+
+    public OsmMapCallout getCalloutView() {
+        return calloutView;
+    }
+
+    private InfoWindow getCustomInfoWindow() {
+        if (calloutView == null) {
+            return null;
+        }
+
+        if (customInfoWindowCache == null) {
+            customInfoWindowCache = new CustomInfoWindow(org.osmdroid.library.R.layout.bonuspack_bubble,
+                    mapView);
+        }
+
+        LinearLayout bubbleView = (LinearLayout) customInfoWindowCache.getView();
+        if (defaultBubbleDrawable == null) {
+            defaultBubbleDrawable = bubbleView.getBackground();
+        }
+
+        boolean showDrawBubble = !calloutView.getTooltip();
+        if (showDrawBubble && bubbleView.getBackground() == null) {
+            bubbleView.setBackground(defaultBubbleDrawable);
+            Rect padding = new Rect();
+            if (defaultBubbleDrawable.getPadding(padding)) {
+                bubbleView.setPadding(padding.left, padding.top, padding.right, padding.bottom);
+            }
+        } else if (!showDrawBubble && bubbleView.getBackground() != null) {
+            bubbleView.setBackground(null);
+            bubbleView.setPadding(0, 0, 0, 0);
+        }
+        bubbleView.removeAllViews();
+
+        bubbleView.addView(calloutView, new LinearLayout.LayoutParams(
+                calloutView.width,
+                calloutView.height,
+                0f
+        ));
+        return customInfoWindowCache;
+    }
+
+    private int getDrawableResourceByName(String name) {
+        return getResources().getIdentifier(
+                name,
+                "drawable",
+                getContext().getPackageName());
+    }
+
+    private Drawable getBitmapDescriptorByName(String name) {
+        return getResources().getDrawable(getDrawableResourceByName(name));
+    }
+
+    private void infoWindowPressed(MotionEvent e) {
+        if (this.onCalloutPressListener != null) {
+            onCalloutPressListener.OnCalloutPress(this);
+        }
+    }
+
+    OnTouchListener infoWindowTouched = new OnTouchListener() {
+        public boolean onTouch(View v, MotionEvent e) {
+            if (e.getAction() == ACTION_UP) {
+                OsmMapMarker.this.infoWindowPressed(e);
+            }
+            return true;
+        }
+    };
+
+    public void setOnCalloutPressListener(OnCalloutPressListener onCalloutPressListener) {
+        this.onCalloutPressListener = onCalloutPressListener;
+    }
+
+    public OnCalloutPressListener getOnCalloutPressListener() {
+        return onCalloutPressListener;
+    }
+
+    private class CustomInfoWindow extends InfoWindow {
+        public CustomInfoWindow(int resId, MapView mapView) {
+            super(resId, mapView);
+
+            this.mView.setOnTouchListener(OsmMapMarker.this.infoWindowTouched);
+        }
+
+        @Override
+        public void onOpen(Object o) {
+            closeAllInfoWindowsOn(this.getMapView());
+        }
+
+        @Override
+        public void onClose() {
+        }
+    }
+
+    public abstract static class OnCalloutPressListener {
+        public abstract void OnCalloutPress(OsmMapMarker markerView);
+    }
+}

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapMarker.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapMarker.java
@@ -13,6 +13,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.widget.LinearLayout;
 
+import com.airbnb.android.react.maps.R;
 import com.facebook.common.references.CloseableReference;
 import com.facebook.datasource.DataSource;
 import com.facebook.drawee.backends.pipeline.Fresco;
@@ -398,8 +399,8 @@ public class OsmMapMarker extends OsmMapFeature {
         }
 
         if (customInfoWindowCache == null) {
-            customInfoWindowCache = new CustomInfoWindow(org.osmdroid.library.R.layout.bonuspack_bubble,
-                    mapView);
+            int layoutID = getResources().getIdentifier("bonuspack_bubble", "layout", getContext().getPackageName());
+            customInfoWindowCache = new CustomInfoWindow(layoutID, mapView);
         }
 
         LinearLayout bubbleView = (LinearLayout) customInfoWindowCache.getView();

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapMarker.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapMarker.java
@@ -13,7 +13,6 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.widget.LinearLayout;
 
-import com.airbnb.android.react.maps.R;
 import com.facebook.common.references.CloseableReference;
 import com.facebook.datasource.DataSource;
 import com.facebook.drawee.backends.pipeline.Fresco;
@@ -274,7 +273,7 @@ public class OsmMapMarker extends OsmMapFeature {
         defaultInfoWindow = marker.getInfoWindow();
         defaultInfoWindow.getView().setOnTouchListener(OsmMapMarker.this.infoWindowTouched);
         mapView = map;
-        initProperties(marker);
+        fillProperties(marker);
         map.getOverlays().add(marker);
     }
 
@@ -318,17 +317,24 @@ public class OsmMapMarker extends OsmMapFeature {
         }
     }
 
-    private void initProperties(Marker marker) {
+    private void fillProperties(Marker marker) {
         marker.setPosition(position);
-        if (anchorIsSet) marker.setAnchor(anchorX, anchorY);
-        if (calloutAnchorIsSet) marker.setInfoWindowAnchor(calloutAnchorX, calloutAnchorY);
+        if (anchorIsSet) {
+            marker.setAnchor(anchorX, anchorY);
+        } else {
+            marker.setAnchor(0.5f, 1.0f);
+        }
+        if (calloutAnchorIsSet) {
+            marker.setInfoWindowAnchor(calloutAnchorX, calloutAnchorY);
+        } else {
+            marker.setInfoWindowAnchor(0.5f, 0);
+        }
         marker.setInfoWindow(getInfoWindow());
         marker.setTitle(title);
         marker.setSnippet(snippet);
         marker.setRotation(rotation);
         marker.setFlat(flat);
         marker.setDraggable(draggable);
-        // TODO: options.zIndex(zIndex);
         marker.setAlpha(opacity);
         marker.setIcon(getIcon());
     }
@@ -337,23 +343,7 @@ public class OsmMapMarker extends OsmMapFeature {
         if (marker == null) {
             return;
         }
-
-        marker.setInfoWindow(getInfoWindow());
-
-        marker.setIcon(getIcon());
-
-        if (anchorIsSet) {
-            marker.setAnchor(anchorX, anchorY);
-        } else {
-            marker.setAnchor(0.5f, 1.0f);
-        }
-
-        if (calloutAnchorIsSet) {
-            marker.setInfoWindowAnchor(calloutAnchorX, calloutAnchorY);
-        } else {
-            marker.setInfoWindowAnchor(0.5f, 0);
-        }
-
+        fillProperties(marker);
         mapView.invalidate();
     }
 

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapMarker.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapMarker.java
@@ -76,6 +76,9 @@ public class OsmMapMarker extends OsmMapFeature {
     private boolean calloutAnchorIsSet;
 
     private boolean hasCustomMarkerView = false;
+    private boolean isCustomMarkerViewDirty = false;
+    private Bitmap customMarkerViewBitmap = null;
+
     private OnCalloutPressListener onCalloutPressListener;
 
     private final DraweeHolder<?> logoHolder;
@@ -294,7 +297,7 @@ public class OsmMapMarker extends OsmMapFeature {
         if (hasCustomMarkerView) {
             // creating a bitmap from an arbitrary view
             if (iconBitmapDrawable != null) {
-                Bitmap viewBitmap = createDrawable();
+                Bitmap viewBitmap = getCustomMarkerViewBitmap();
                 int width = Math.max(iconBitmap.getWidth(), viewBitmap.getWidth());
                 int height = Math.max(iconBitmap.getHeight(), viewBitmap.getHeight());
                 Bitmap combinedBitmap = Bitmap.createBitmap(width, height, iconBitmap.getConfig());
@@ -303,7 +306,7 @@ public class OsmMapMarker extends OsmMapFeature {
                 canvas.drawBitmap(viewBitmap, 0, 0, null);
                 return new BitmapDrawable(getResources(), combinedBitmap);
             } else {
-                return new BitmapDrawable(getResources(), createDrawable());
+                return new BitmapDrawable(getResources(), getCustomMarkerViewBitmap());
             }
         } else if (iconBitmapDrawable != null) {
             // use local image as a marker
@@ -348,6 +351,7 @@ public class OsmMapMarker extends OsmMapFeature {
     public void update(int width, int height) {
         this.width = width;
         this.height = height;
+        isCustomMarkerViewDirty = true;
         update();
     }
 
@@ -361,7 +365,15 @@ public class OsmMapMarker extends OsmMapFeature {
         return null;
     }
 
-    private Bitmap createDrawable() {
+    private Bitmap getCustomMarkerViewBitmap() {
+        if (isCustomMarkerViewDirty || customMarkerViewBitmap == null) {
+            customMarkerViewBitmap = createCustomMarkerViewBitmap();
+            isCustomMarkerViewDirty = false;
+        }
+        return customMarkerViewBitmap;
+    }
+
+    private Bitmap createCustomMarkerViewBitmap() {
         int width = this.width <= 0 ? 100 : this.width;
         int height = this.height <= 0 ? 100 : this.height;
         this.buildDrawingCache();

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapMarkerManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapMarkerManager.java
@@ -1,0 +1,219 @@
+package com.airbnb.android.react.maps.osmdroid;
+
+import android.graphics.Color;
+import android.view.View;
+
+import com.airbnb.android.react.maps.SizeReportingShadowNode;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.common.MapBuilder;
+import com.facebook.react.uimanager.LayoutShadowNode;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.ViewGroupManager;
+import com.facebook.react.uimanager.annotations.ReactProp;
+
+import org.osmdroid.views.overlay.Marker;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+public class OsmMapMarkerManager extends ViewGroupManager<OsmMapMarker> {
+
+    private static final int SHOW_INFO_WINDOW = 1;
+    private static final int HIDE_INFO_WINDOW = 2;
+
+    public OsmMapMarkerManager() {
+    }
+
+    @Override
+    public String getName() {
+        return "OsmMapMarker";
+    }
+
+    @Override
+    public OsmMapMarker createViewInstance(ThemedReactContext context) {
+        return new OsmMapMarker(context);
+    }
+
+    @Override
+    public void onDropViewInstance(OsmMapMarker view) {
+        view.cleanup();
+        super.onDropViewInstance(view);
+    }
+
+    @ReactProp(name = "coordinate")
+    public void setCoordinate(OsmMapMarker view, ReadableMap map) {
+        view.setCoordinate(map);
+    }
+
+    @ReactProp(name = "title")
+    public void setTitle(OsmMapMarker view, String title) {
+        view.setTitle(title);
+    }
+
+    @ReactProp(name = "identifier")
+    public void setIdentifier(OsmMapMarker view, String identifier) {
+        view.setIdentifier(identifier);
+    }
+
+    @ReactProp(name = "description")
+    public void setDescription(OsmMapMarker view, String description) {
+        view.setSnippet(description);
+    }
+
+    // NOTE(lmr):
+    // android uses normalized coordinate systems for this, and is provided through the
+    // `anchor` property  and `calloutAnchor` instead.  Perhaps some work could be done
+    // to normalize iOS and android to use just one of the systems.
+//    @ReactProp(name = "centerOffset")
+//    public void setCenterOffset(AirMapMarker view, ReadableMap map) {
+//
+//    }
+//
+//    @ReactProp(name = "calloutOffset")
+//    public void setCalloutOffset(AirMapMarker view, ReadableMap map) {
+//
+//    }
+
+    @ReactProp(name = "anchor")
+    public void setAnchor(OsmMapMarker view, ReadableMap map) {
+        // should default to (0.5, 1) (bottom middle)
+        double x = map != null && map.hasKey("x") ? map.getDouble("x") : 0.5;
+        double y = map != null && map.hasKey("y") ? map.getDouble("y") : 1.0;
+        view.setAnchor(x, y);
+    }
+
+    @ReactProp(name = "calloutAnchor")
+    public void setCalloutAnchor(OsmMapMarker view, ReadableMap map) {
+        // should default to (0.5, 0) (top middle)
+        double x = map != null && map.hasKey("x") ? map.getDouble("x") : 0.5;
+        double y = map != null && map.hasKey("y") ? map.getDouble("y") : 0.0;
+        view.setCalloutAnchor(x, y);
+    }
+
+    @ReactProp(name = "image")
+    public void setImage(OsmMapMarker view, @Nullable String source) {
+        view.setImage(source);
+    }
+//    public void setImage(AirMapMarker view, ReadableMap image) {
+//        view.setImage(image);
+//    }
+
+    @ReactProp(name = "pinColor", defaultInt = Color.RED, customType = "Color")
+    public void setPinColor(OsmMapMarker view, int pinColor) {
+        float[] hsv = new float[3];
+        Color.colorToHSV(pinColor, hsv);
+        // NOTE: android only supports a hue
+        view.setMarkerHue(hsv[0]);
+    }
+
+    @ReactProp(name = "rotation", defaultFloat = 0.0f)
+    public void setMarkerRotation(OsmMapMarker view, float rotation) {
+        view.setRotation(rotation);
+    }
+
+    @ReactProp(name = "flat", defaultBoolean = false)
+    public void setFlat(OsmMapMarker view, boolean flat) {
+        view.setFlat(flat);
+    }
+
+    @ReactProp(name = "draggable", defaultBoolean = false)
+    public void setDraggable(OsmMapMarker view, boolean draggable) {
+        view.setDraggable(draggable);
+    }
+
+//  @Override
+//  @ReactProp(name = "zIndex", defaultFloat = 0.0f)
+//  public void setZIndex(AirMapMarker view, float zIndex) {
+//    super.setZIndex(view, zIndex);
+//    int integerZIndex = Math.round(zIndex);
+//    view.setZIndex(integerZIndex);
+//  }
+
+    @Override
+    @ReactProp(name = "opacity", defaultFloat = 1.0f)
+    public void setOpacity(OsmMapMarker view, float opacity) {
+        super.setOpacity(view, opacity);
+        view.setOpacity(opacity);
+    }
+
+    @Override
+    public void addView(OsmMapMarker parent, View child, int index) {
+        // if an <Callout /> component is a child, then it is a callout view, NOT part of the
+        // marker.
+        if (child instanceof OsmMapCallout) {
+            parent.setCalloutView((OsmMapCallout) child);
+        } else {
+            super.addView(parent, child, index);
+            parent.update();
+        }
+    }
+
+    @Override
+    public void removeViewAt(OsmMapMarker parent, int index) {
+        super.removeViewAt(parent, index);
+        parent.update();
+    }
+
+    @Override
+    @Nullable
+    public Map<String, Integer> getCommandsMap() {
+        return MapBuilder.of(
+                "showCallout", SHOW_INFO_WINDOW,
+                "hideCallout", HIDE_INFO_WINDOW
+        );
+    }
+
+    @Override
+    public void receiveCommand(OsmMapMarker view, int commandId, @Nullable ReadableArray args) {
+    switch (commandId) {
+      case SHOW_INFO_WINDOW:
+        ((Marker) view.getFeature()).showInfoWindow();
+        break;
+
+      case HIDE_INFO_WINDOW:
+        ((Marker) view.getFeature()).closeInfoWindow();
+        break;
+    }
+    }
+
+    @Override
+    @Nullable
+    public Map getExportedCustomDirectEventTypeConstants() {
+        Map<String, Map<String, String>> map = MapBuilder.of(
+                "onPress", MapBuilder.of("registrationName", "onPress"),
+                "onCalloutPress", MapBuilder.of("registrationName", "onCalloutPress"),
+                "onDragStart", MapBuilder.of("registrationName", "onDragStart"),
+                "onDrag", MapBuilder.of("registrationName", "onDrag"),
+                "onDragEnd", MapBuilder.of("registrationName", "onDragEnd")
+        );
+
+        map.putAll(MapBuilder.of(
+                "onDragStart", MapBuilder.of("registrationName", "onDragStart"),
+                "onDrag", MapBuilder.of("registrationName", "onDrag"),
+                "onDragEnd", MapBuilder.of("registrationName", "onDragEnd")
+        ));
+
+        return map;
+    }
+
+    @Override
+    public LayoutShadowNode createShadowNodeInstance() {
+        // we use a custom shadow node that emits the width/height of the view
+        // after layout with the updateExtraData method. Without this, we can't generate
+        // a bitmap of the appropriate width/height of the rendered view.
+        return new SizeReportingShadowNode();
+    }
+
+    @Override
+    public void updateExtraData(OsmMapMarker view, Object extraData) {
+        // This method is called from the shadow node with the width/height of the rendered
+        // marker view.
+        HashMap<String, Float> data = (HashMap<String, Float>) extraData;
+        float width = data.get("width");
+        float height = data.get("height");
+        view.update((int) width, (int) height);
+    }
+}

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapPolygon.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapPolygon.java
@@ -1,0 +1,107 @@
+package com.airbnb.android.react.maps.osmdroid;
+
+import android.content.Context;
+
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
+
+import org.osmdroid.util.GeoPoint;
+import org.osmdroid.views.MapView;
+import org.osmdroid.views.overlay.Polygon;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class OsmMapPolygon extends OsmMapFeature {
+
+  private Polygon polygon;
+
+  private List<GeoPoint> coordinates;
+  private int strokeColor;
+  private int fillColor;
+  private float strokeWidth;
+  private boolean geodesic;
+  private float zIndex;
+  private MapView mapView;
+
+  public OsmMapPolygon(Context context) {
+    super(context);
+  }
+
+  public void setCoordinates(ReadableArray coordinates) {
+    // it's kind of a bummer that we can't run map() or anything on the ReadableArray
+    this.coordinates = new ArrayList<>(coordinates.size()+1);
+    for (int i = 0; i < coordinates.size(); i++) {
+      ReadableMap coordinate = coordinates.getMap(i);
+      this.coordinates.add(i,
+          new GeoPoint(coordinate.getDouble("latitude"), coordinate.getDouble("longitude")));
+    }
+    this.coordinates.add(this.coordinates.get(0));
+    if (polygon != null) {
+      polygon.setPoints(this.coordinates);
+      mapView.invalidate();
+    }
+  }
+
+  public void setFillColor(int color) {
+    this.fillColor = color;
+    if (polygon != null) {
+      polygon.setFillColor(color);
+      mapView.invalidate();
+    }
+  }
+
+  public void setStrokeColor(int color) {
+    this.strokeColor = color;
+    if (polygon != null) {
+      polygon.setStrokeColor(color);
+      mapView.invalidate();
+    }
+  }
+
+  public void setStrokeWidth(float width) {
+    this.strokeWidth = width;
+    if (polygon != null) {
+      polygon.setStrokeWidth(width);
+      mapView.invalidate();
+    }
+  }
+
+//  public void setGeodesic(boolean geodesic) {
+//    this.geodesic = geodesic;
+//    if (polygon != null) {
+//      polygon.setGeodesic(geodesic);
+//    }
+//  }
+
+//  public void setZIndex(float zIndex) {
+//    this.zIndex = zIndex;
+//    if (polygon != null) {
+//      polygon.setZIndex(zIndex);
+//    }
+//  }
+
+  @Override
+  public Object getFeature() {
+    return polygon;
+  }
+
+  @Override
+  public void addToMap(MapView map) {
+    polygon = new Polygon();
+    mapView = map;
+    polygon.setPoints(coordinates);
+    polygon.setFillColor(fillColor);
+    polygon.setStrokeColor(strokeColor);
+    polygon.setStrokeWidth(strokeWidth);
+    map.getOverlays().add(polygon);
+    mapView.invalidate();
+  }
+
+  @Override
+  public void removeFromMap(MapView map) {
+    map.getOverlays().remove(polygon);
+    polygon = null;
+    mapView = null;
+  }
+}

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapPolygonManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapPolygonManager.java
@@ -1,0 +1,83 @@
+package com.airbnb.android.react.maps.osmdroid;
+
+import android.content.Context;
+import android.graphics.Color;
+import android.os.Build;
+import android.util.DisplayMetrics;
+import android.view.WindowManager;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.common.MapBuilder;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.ViewGroupManager;
+import com.facebook.react.uimanager.annotations.ReactProp;
+
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+public class OsmMapPolygonManager extends ViewGroupManager<OsmMapPolygon> {
+  private final DisplayMetrics metrics;
+
+  public OsmMapPolygonManager(ReactApplicationContext reactContext) {
+    super();
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+      metrics = new DisplayMetrics();
+      ((WindowManager) reactContext.getSystemService(Context.WINDOW_SERVICE))
+          .getDefaultDisplay()
+          .getRealMetrics(metrics);
+    } else {
+      metrics = reactContext.getResources().getDisplayMetrics();
+    }
+  }
+
+  @Override
+  public String getName() {
+    return "OsmMapPolygon";
+  }
+
+  @Override
+  public OsmMapPolygon createViewInstance(ThemedReactContext context) {
+    return new OsmMapPolygon(context);
+  }
+
+  @ReactProp(name = "coordinates")
+  public void setCoordinate(OsmMapPolygon view, ReadableArray coordinates) {
+    view.setCoordinates(coordinates);
+  }
+
+  @ReactProp(name = "strokeWidth", defaultFloat = 1f)
+  public void setStrokeWidth(OsmMapPolygon view, float widthInPoints) {
+    float widthInScreenPx = metrics.density * widthInPoints; // done for parity with iOS
+    view.setStrokeWidth(widthInScreenPx);
+  }
+
+  @ReactProp(name = "fillColor", defaultInt = Color.RED, customType = "Color")
+  public void setFillColor(OsmMapPolygon view, int color) {
+    view.setFillColor(color);
+  }
+
+  @ReactProp(name = "strokeColor", defaultInt = Color.RED, customType = "Color")
+  public void setStrokeColor(OsmMapPolygon view, int color) {
+    view.setStrokeColor(color);
+  }
+
+//  @ReactProp(name = "geodesic", defaultBoolean = false)
+//  public void setGeodesic(AirMapPolygon view, boolean geodesic) {
+//    view.setGeodesic(geodesic);
+//  }
+//
+//  @ReactProp(name = "zIndex", defaultFloat = 1.0f)
+//  public void setZIndex(AirMapPolygon view, float zIndex) {
+//    view.setZIndex(zIndex);
+//  }
+
+  @Override
+  @Nullable
+  public Map getExportedCustomDirectEventTypeConstants() {
+    return MapBuilder.of(
+        "onPress", MapBuilder.of("registrationName", "onPress")
+    );
+  }
+}

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapPolyline.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapPolyline.java
@@ -1,0 +1,97 @@
+package com.airbnb.android.react.maps.osmdroid;
+
+import android.content.Context;
+
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
+
+import org.osmdroid.util.GeoPoint;
+import org.osmdroid.views.MapView;
+import org.osmdroid.views.overlay.Polyline;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class OsmMapPolyline extends OsmMapFeature {
+
+  private Polyline polyline;
+
+  private List<GeoPoint> coordinates;
+  private int color;
+  private float width;
+  private boolean geodesic;
+//  private float zIndex;
+  private MapView mapView;
+
+  public OsmMapPolyline(Context context) {
+    super(context);
+  }
+
+  public void setCoordinates(ReadableArray coordinates) {
+    this.coordinates = new ArrayList<>(coordinates.size());
+    for (int i = 0; i < coordinates.size(); i++) {
+      ReadableMap coordinate = coordinates.getMap(i);
+      this.coordinates.add(i,
+          new GeoPoint(coordinate.getDouble("latitude"), coordinate.getDouble("longitude")));
+    }
+    if (polyline != null) {
+      polyline.setPoints(this.coordinates);
+      mapView.invalidate();
+    }
+  }
+
+  public void setColor(int color) {
+    this.color = color;
+    if (polyline != null) {
+      polyline.setColor(color);
+      mapView.invalidate();
+    }
+  }
+
+  public void setWidth(float width) {
+    this.width = width;
+    if (polyline != null) {
+      polyline.setWidth(width);
+      mapView.invalidate();
+    }
+  }
+
+//  public void setZIndex(float zIndex) {
+//    this.zIndex = zIndex;
+//    if (polyline != null) {
+//      polyline.setZIndex(zIndex);
+//    }
+//  }
+//
+  public void setGeodesic(boolean geodesic) {
+    this.geodesic = geodesic;
+    if (polyline != null) {
+      polyline.setGeodesic(geodesic);
+      mapView.invalidate();
+    }
+  }
+
+  @Override
+  public Object getFeature() {
+    return polyline;
+  }
+
+  @Override
+  public void addToMap(MapView map) {
+    polyline = new Polyline();
+    mapView = map;
+    polyline.setPoints(coordinates);
+    polyline.setColor(color);
+    polyline.setWidth(width);
+    polyline.setGeodesic(geodesic);
+    mapView.getOverlayManager().add(polyline);
+    mapView.invalidate();
+  }
+
+  @Override
+  public void removeFromMap(MapView map) {
+    map.getOverlays().remove(polyline);
+    polyline = null;
+    mapView = null;
+  }
+}

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapPolylineManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapPolylineManager.java
@@ -1,0 +1,78 @@
+package com.airbnb.android.react.maps.osmdroid;
+
+import android.content.Context;
+import android.graphics.Color;
+import android.os.Build;
+import android.util.DisplayMetrics;
+import android.view.WindowManager;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.common.MapBuilder;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.ViewGroupManager;
+import com.facebook.react.uimanager.annotations.ReactProp;
+
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+public class OsmMapPolylineManager extends ViewGroupManager<OsmMapPolyline> {
+  private final DisplayMetrics metrics;
+
+  public OsmMapPolylineManager(ReactApplicationContext reactContext) {
+    super();
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+      metrics = new DisplayMetrics();
+      ((WindowManager) reactContext.getSystemService(Context.WINDOW_SERVICE))
+          .getDefaultDisplay()
+          .getRealMetrics(metrics);
+    } else {
+      metrics = reactContext.getResources().getDisplayMetrics();
+    }
+  }
+
+  @Override
+  public String getName() {
+    return "OsmMapPolyline";
+  }
+
+  @Override
+  public OsmMapPolyline createViewInstance(ThemedReactContext context) {
+    return new OsmMapPolyline(context);
+  }
+
+  @ReactProp(name = "coordinates")
+  public void setCoordinate(OsmMapPolyline view, ReadableArray coordinates) {
+    view.setCoordinates(coordinates);
+  }
+
+  @ReactProp(name = "strokeWidth", defaultFloat = 1f)
+  public void setStrokeWidth(OsmMapPolyline view, float widthInPoints) {
+    float widthInScreenPx = metrics.density * widthInPoints; // done for parity with iOS
+    view.setWidth(widthInScreenPx);
+  }
+
+  @ReactProp(name = "strokeColor", defaultInt = Color.RED, customType = "Color")
+  public void setStrokeColor(OsmMapPolyline view, int color) {
+    view.setColor(color);
+  }
+
+  @ReactProp(name = "geodesic", defaultBoolean = false)
+  public void setGeodesic(OsmMapPolyline view, boolean geodesic) {
+    view.setGeodesic(geodesic);
+  }
+
+//  @ReactProp(name = "zIndex", defaultFloat = 1.0f)
+//  public void setZIndex(AirMapPolyline view, float zIndex) {
+//    view.setZIndex(zIndex);
+//  }
+
+  @Override
+  @Nullable
+  public Map getExportedCustomDirectEventTypeConstants() {
+    return MapBuilder.of(
+        "onPress", MapBuilder.of("registrationName", "onPress")
+    );
+  }
+}

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapUrlTile.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapUrlTile.java
@@ -1,0 +1,91 @@
+package com.airbnb.android.react.maps.osmdroid;
+
+import android.content.Context;
+import android.util.Log;
+
+
+import org.osmdroid.tileprovider.tilesource.ITileSource;
+import org.osmdroid.tileprovider.tilesource.OnlineTileSourceBase;
+import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
+import org.osmdroid.tileprovider.tilesource.XYTileSource;
+import org.osmdroid.util.MapTileIndex;
+import org.osmdroid.views.MapView;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class OsmMapUrlTile extends OsmMapFeature {
+
+  private ITileSource tileSource;
+
+  private String urlTemplate;
+  private float maximumZ = 100.f;
+  private float minimumZ = 0;
+
+  public class OsmMapTileSource extends OnlineTileSourceBase {
+
+    public OsmMapTileSource(final String aName, final int aZoomMinLevel,
+                        final int aZoomMaxLevel, final int aTileSizePixels,
+                        final String urlTemplate) {
+      super(aName, aZoomMinLevel, aZoomMaxLevel, aTileSizePixels,
+              null, new String[] { urlTemplate },null);
+    }
+
+    @Override
+    public String toString(){
+      return name();
+    }
+    @Override
+    public String getTileURLString(final long pMapTileIndex) {
+      String url = getBaseUrl()
+              .replace("{x}", Integer.toString(MapTileIndex.getX(pMapTileIndex)))
+              .replace("{y}", Integer.toString(MapTileIndex.getY(pMapTileIndex)))
+              .replace("{z}", Integer.toString(MapTileIndex.getZoom(pMapTileIndex)));
+
+      Log.e("OsmMapTileSource", url);
+      return url;
+    }
+
+    @Override
+    public String getTileRelativeFilenameString(long pMapTileIndex) {
+      return pathBase()
+              .replace("{x}", Integer.toString(MapTileIndex.getX(pMapTileIndex)))
+              .replace("{y}", Integer.toString(MapTileIndex.getY(pMapTileIndex)))
+              .replace("{z}",  Integer.toString(MapTileIndex.getZoom(pMapTileIndex)));
+    }
+  }
+
+  public OsmMapUrlTile(Context context) {
+    super(context);
+  }
+
+  public void setUrlTemplate(String urlTemplate) {
+    this.urlTemplate = urlTemplate;
+  }
+
+  public void setMaximumZ(float maximumZ) {
+    this.maximumZ = maximumZ;
+  }
+
+  public void setMinimumZ(float minimumZ) {
+    this.minimumZ = minimumZ;
+  }
+
+  @Override
+  public Object getFeature() {
+    return this;
+  }
+
+  @Override
+  public void addToMap(MapView map) {
+    final ITileSource tileSource = new OsmMapTileSource( "OsmMapTileSource", (int)minimumZ, (int)maximumZ, 256, urlTemplate);
+    map.setTileSource(tileSource);
+    map.setTilesScaledToDpi(true);
+  }
+
+  @Override
+  public void removeFromMap(MapView map) {
+    map.setTileSource(TileSourceFactory.DEFAULT_TILE_SOURCE);
+    map.setTilesScaledToDpi(true);
+  }
+}

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapUrlTileManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapUrlTileManager.java
@@ -1,0 +1,44 @@
+package com.airbnb.android.react.maps.osmdroid;
+
+import android.content.Context;
+import android.os.Build;
+import android.util.DisplayMetrics;
+import android.view.WindowManager;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.ViewGroupManager;
+import com.facebook.react.uimanager.annotations.ReactProp;
+
+public class OsmMapUrlTileManager extends ViewGroupManager<OsmMapUrlTile> {
+
+  public OsmMapUrlTileManager() {
+    super();
+  }
+
+  @Override
+  public String getName() {
+    return "OsmMapUrlTile";
+  }
+
+  @Override
+  public OsmMapUrlTile createViewInstance(ThemedReactContext context) {
+    return new OsmMapUrlTile(context);
+  }
+
+  @ReactProp(name = "urlTemplate")
+  public void setUrlTemplate(OsmMapUrlTile view, String urlTemplate) {
+    view.setUrlTemplate(urlTemplate);
+  }
+
+  @ReactProp(name = "minimumZ", defaultFloat = 0.0f)
+  public void setMinimumZ(OsmMapUrlTile view, float minimumZ) {
+    view.setMinimumZ(minimumZ);
+  }
+
+  @ReactProp(name = "maximumZ", defaultFloat = 100.0f)
+  public void setMaximumZ(OsmMapUrlTile view, float maximumZ) {
+    view.setMaximumZ(maximumZ);
+  }
+
+}

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapView.java
@@ -1,15 +1,20 @@
 package com.airbnb.android.react.maps.osmdroid;
 
+import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Point;
+import android.os.Build;
 import android.os.Handler;
 import android.support.v4.view.GestureDetectorCompat;
 import android.support.v4.view.MotionEventCompat;
+import android.util.DisplayMetrics;
 import android.view.GestureDetector;
 import android.view.MotionEvent;
 import android.view.ScaleGestureDetector;
 import android.view.View;
+import android.view.WindowManager;
 
+import com.airbnb.android.react.maps.AirMapUrlTile;
 import com.airbnb.android.react.maps.osmdroid.overlays.InterceptDoubleTapOverlay;
 import com.airbnb.android.react.maps.osmdroid.overlays.InterceptScrollOverlay;
 import com.airbnb.android.react.maps.osmdroid.utils.LatLngBoundsUtils;
@@ -110,7 +115,8 @@ public class OsmMapView extends MapView implements MapView.OnFirstLayoutListener
                 });
 
         eventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
-        this.setTileSource(TileSourceFactory.MAPNIK);
+        this.setTileSource(TileSourceFactory.DEFAULT_TILE_SOURCE);
+        this.setTilesScaledToDpi(true);
     }
 
     /*
@@ -297,15 +303,15 @@ public class OsmMapView extends MapView implements MapView.OnFirstLayoutListener
             features.add(index, polygonView);
             Polygon polygon = (Polygon) polygonView.getFeature();
             polygonMap.put(polygon, polygonView);
-        } /*else if (child instanceof AirMapCircle) {
+        } else if (child instanceof OsmMapUrlTile) {
+            OsmMapUrlTile urlTileView = (OsmMapUrlTile) child;
+            urlTileView.addToMap(this);
+            features.add(index, urlTileView);
+        }/*else if (child instanceof AirMapCircle) {
             AirMapCircle circleView = (AirMapCircle) child;
             circleView.addToMap(map);
             features.add(index, circleView);
-        } else if (child instanceof AirMapUrlTile) {
-            AirMapUrlTile urlTileView = (AirMapUrlTile) child;
-            urlTileView.addToMap(map);
-            features.add(index, urlTileView);
-        } else {
+        }  else {
             ViewGroup children = (ViewGroup) child;
             for (int i = 0; i < children.getChildCount(); i++) {
                 addFeature(children.getChildAt(i), index);

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapView.java
@@ -1,0 +1,637 @@
+package com.airbnb.android.react.maps.osmdroid;
+
+import android.graphics.Canvas;
+import android.graphics.Point;
+import android.os.Handler;
+import android.support.v4.view.GestureDetectorCompat;
+import android.support.v4.view.MotionEventCompat;
+import android.view.GestureDetector;
+import android.view.MotionEvent;
+import android.view.ScaleGestureDetector;
+import android.view.View;
+
+import com.airbnb.android.react.maps.osmdroid.overlays.InterceptDoubleTapOverlay;
+import com.airbnb.android.react.maps.osmdroid.overlays.InterceptScrollOverlay;
+import com.airbnb.android.react.maps.osmdroid.utils.LatLngBoundsUtils;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableNativeMap;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.events.EventDispatcher;
+
+import org.osmdroid.api.IGeoPoint;
+import org.osmdroid.events.DelayedMapListener;
+import org.osmdroid.events.MapEventsReceiver;
+import org.osmdroid.events.MapListener;
+import org.osmdroid.events.ScrollEvent;
+import org.osmdroid.events.ZoomEvent;
+import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
+import org.osmdroid.util.BoundingBox;
+import org.osmdroid.util.GeoPoint;
+import org.osmdroid.util.TileSystem;
+import org.osmdroid.views.MapView;
+import org.osmdroid.views.Projection;
+import org.osmdroid.views.overlay.MapEventsOverlay;
+import org.osmdroid.views.overlay.Marker;
+import org.osmdroid.views.overlay.Overlay;
+import org.osmdroid.views.overlay.Polygon;
+import org.osmdroid.views.overlay.Polyline;
+import org.osmdroid.views.overlay.gestures.RotationGestureOverlay;
+import org.osmdroid.views.overlay.infowindow.InfoWindow;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class OsmMapView extends MapView implements MapView.OnFirstLayoutListener {
+
+    private final int baseMapPadding = 50;
+
+    private BoundingBox boundsToMove;
+    private boolean isMonitoringRegion = false;
+    private boolean isTouchDown = false;
+    private boolean handlePanDrag = false;
+    private boolean moveOnMarkerPress = true;
+    private boolean initialRegionSet = false;
+
+    private final List<OsmMapFeature> features = new ArrayList<>();
+    private final Map<Marker, OsmMapMarker> markerMap = new HashMap<>();
+    private final Map<Polyline, OsmMapPolyline> polylineMap = new HashMap<>();
+    private final Map<Polygon, OsmMapPolygon> polygonMap = new HashMap<>();
+    private final ScaleGestureDetector scaleDetector;
+    private final GestureDetectorCompat gestureDetector;
+    private final OsmMapManager manager;
+    private final ThemedReactContext context;
+    private final EventDispatcher eventDispatcher;
+
+    public OsmMapView(ThemedReactContext reactContext,
+                      ReactApplicationContext appContext,
+                      OsmMapManager manager) {
+        super(reactContext.getApplicationContext());
+
+        this.manager = manager;
+        this.context = reactContext;
+        this.addOnFirstLayoutListener(this);
+        this.getController().setZoom(10.0);
+
+        final OsmMapView view = this;
+        scaleDetector =
+                new ScaleGestureDetector(reactContext,
+                        new ScaleGestureDetector.SimpleOnScaleGestureListener() {
+                            @Override
+                            public boolean onScaleBegin(ScaleGestureDetector detector) {
+                                view.startMonitoringRegion();
+                                return true; // stop recording this gesture. let mapview handle it.
+                            }
+                        });
+
+        gestureDetector =
+                new GestureDetectorCompat(reactContext, new GestureDetector.SimpleOnGestureListener() {
+                    @Override
+                    public boolean onDoubleTap(MotionEvent e) {
+                        view.startMonitoringRegion();
+                        return false;
+                    }
+
+                    @Override
+                    public boolean onScroll(MotionEvent e1, MotionEvent e2, float distanceX,
+                                            float distanceY) {
+                        if (handlePanDrag) {
+                            onPanDrag(e2);
+                        }
+                        view.startMonitoringRegion();
+                        return false;
+                    }
+                });
+
+        eventDispatcher = reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher();
+        this.setTileSource(TileSourceFactory.MAPNIK);
+    }
+
+    @Override
+    public void onFirstLayout(View view, int i, int i1, int i2, int i3) {
+        manager.pushEvent(context, this, "onMapReady", new WritableNativeMap());
+
+        this.addMapListener(new DelayedMapListener(new MapListener() {
+            @Override
+            public boolean onScroll(ScrollEvent scrollEvent) {
+                OsmMapView mapView = OsmMapView.this;
+                BoundingBox bounds = mapView.getBoundingBox();
+                IGeoPoint center = mapView.getMapCenter();
+                lastBoundsEmitted = bounds;
+                eventDispatcher.dispatchEvent(new OsmRegionChangeEvent(getId(), bounds, center, isTouchDown));
+                mapView.stopMonitoringRegion();
+                return true;
+            }
+
+            @Override
+            public boolean onZoom(ZoomEvent zoomEvent) {
+                OsmMapView mapView = OsmMapView.this;
+                BoundingBox bounds = mapView.getBoundingBox();
+                IGeoPoint center = mapView.getMapCenter();
+                lastBoundsEmitted = bounds;
+                eventDispatcher.dispatchEvent(new OsmRegionChangeEvent(getId(), bounds, center, isTouchDown));
+                mapView.stopMonitoringRegion();
+                return true;
+            }
+        }, 100));
+
+        MapEventsOverlay OverlayEvents = new MapEventsOverlay(new MapEventsReceiver() {
+            @Override
+            public boolean singleTapConfirmedHelper(GeoPoint p) {
+                WritableMap event = makeClickEventData(p);
+                event.putString("action", "press");
+                manager.pushEvent(context, OsmMapView.this, "onPress", event);
+                InfoWindow.closeAllInfoWindowsOn(OsmMapView.this);
+                return false;
+            }
+
+            @Override
+            public boolean longPressHelper(GeoPoint p) {
+                WritableMap event = makeClickEventData(p);
+                event.putString("action", "long-press");
+                manager.pushEvent(context, OsmMapView.this, "onLongPress", event);
+                return false;
+            }
+        });
+        this.getOverlays().add(OverlayEvents);
+
+        // listen for polygon click
+        this.getOverlays().add(new Overlay() {
+            @Override
+            public void draw(Canvas canvas, MapView mapView, boolean b) {
+            }
+
+            @Override
+            public boolean onSingleTapConfirmed(MotionEvent e, MapView mapView) {
+                for (Polygon polygon : polygonMap.keySet()) {
+                    if (polygon.contains(e)) {
+                        WritableMap event = makeClickEventData(polygon.getPoints().get(0));
+                        event.putString("action", "polygon-press");
+                        manager.pushEvent(context, polygonMap.get(polygon), "onPress", event);
+                        return true;
+                    }
+                }
+                return super.onSingleTapConfirmed(e, mapView);
+            }
+        });
+    }
+
+    public void setInitialRegion(ReadableMap initialRegion) {
+        if (!initialRegionSet && initialRegion != null) {
+            setRegion(initialRegion);
+            initialRegionSet = true;
+        }
+    }
+
+    public void setRegion(ReadableMap region) {
+        if (region == null) return;
+
+        Double lng = region.getDouble("longitude");
+        Double lat = region.getDouble("latitude");
+        Double lngDelta = region.getDouble("longitudeDelta");
+        Double latDelta = region.getDouble("latitudeDelta");
+        BoundingBox bounds = new BoundingBox(
+                lat + latDelta / 2, lng + lngDelta / 2,
+                lat - latDelta / 2, lng - lngDelta / 2
+        );
+        if (super.getHeight() <= 0 || super.getWidth() <= 0) {
+            // in this case, our map has not been laid out yet, so we save the bounds in a local
+            // variable, and make a guess of zoomLevel 10. Not to worry, though: as soon as layout
+            // occurs, we will move the camera to the saved bounds. Note that if we tried to move
+            // to the bounds now, it would trigger an exception.
+            this.getController().setZoom(10.0f);
+            this.getController().setCenter(bounds.getCenterWithDateLine());
+            boundsToMove = bounds;
+        } else {
+            int width = getWidth();
+            int height = getHeight();
+            double zoom = TileSystem.getBoundingBoxZoom(bounds, width, height);
+            this.getController().setZoom(zoom);
+            this.getController().setCenter(bounds.getCenterWithDateLine());
+            boundsToMove = null;
+        }
+    }
+
+    public void setMoveOnMarkerPress(boolean moveOnPress) {
+        this.moveOnMarkerPress = moveOnPress;
+    }
+
+    public void setHandlePanDrag(boolean handlePanDrag) {
+        this.handlePanDrag = handlePanDrag;
+    }
+
+    public void addFeature(View child, int index) {
+        // Our desired API is to pass up annotations/overlays as children to the mapview component.
+        // This is where we intercept them and do the appropriate underlying mapview action.
+        if (child instanceof OsmMapMarker) {
+            OsmMapMarker annotation = (OsmMapMarker) child;
+            annotation.addToMap(this);
+            annotation.setOnCalloutPressListener(onCalloutPressListener);
+            features.add(index, annotation);
+            Marker marker = (Marker) annotation.getFeature();
+            markerMap.put(marker, annotation);
+            marker.setOnMarkerClickListener(onMarkerClickListener);
+            marker.setOnMarkerDragListener(onMarkerDragListener);
+        } else if (child instanceof OsmMapPolyline) {
+            OsmMapPolyline polylineView = (OsmMapPolyline) child;
+            polylineView.addToMap(this);
+            features.add(index, polylineView);
+            Polyline polyline = (Polyline) polylineView.getFeature();
+            polylineMap.put(polyline, polylineView);
+            polyline.setOnClickListener(onPolylineClickListener);
+        } else if (child instanceof OsmMapPolygon) {
+            OsmMapPolygon polygonView = (OsmMapPolygon) child;
+            polygonView.addToMap(this);
+            features.add(index, polygonView);
+            Polygon polygon = (Polygon) polygonView.getFeature();
+            polygonMap.put(polygon, polygonView);
+        } /*else if (child instanceof AirMapCircle) {
+            AirMapCircle circleView = (AirMapCircle) child;
+            circleView.addToMap(map);
+            features.add(index, circleView);
+        } else if (child instanceof AirMapUrlTile) {
+            AirMapUrlTile urlTileView = (AirMapUrlTile) child;
+            urlTileView.addToMap(map);
+            features.add(index, urlTileView);
+        } else {
+            ViewGroup children = (ViewGroup) child;
+            for (int i = 0; i < children.getChildCount(); i++) {
+                addFeature(children.getChildAt(i), index);
+            }
+        }*/
+    }
+
+    @Override
+    public void onViewAdded(View child) {
+        super.onViewAdded(child);
+        manager.invalidateNode(this);
+    }
+
+    @Override
+    public void onViewRemoved(View child) {
+        super.onViewRemoved(child);
+        manager.invalidateNode(this);
+    }
+
+    public int getFeatureCount() {
+        return features.size();
+    }
+
+    public View getFeatureAt(int index) {
+        return features.get(index);
+    }
+
+    public void removeFeatureAt(int index) {
+        OsmMapFeature feature = features.remove(index);
+        if (feature instanceof OsmMapMarker) {
+            markerMap.remove(feature.getFeature());
+        }
+        feature.removeFromMap(this);
+    }
+
+    public WritableMap makeClickEventData(IGeoPoint point) {
+        WritableMap event = new WritableNativeMap();
+
+        WritableMap coordinate = new WritableNativeMap();
+        coordinate.putDouble("latitude", point.getLatitude());
+        coordinate.putDouble("longitude", point.getLongitude());
+        event.putMap("coordinate", coordinate);
+
+        Projection projection = this.getProjection();
+        Point screenPoint = projection.toPixels(point, null);
+
+        WritableMap position = new WritableNativeMap();
+        position.putDouble("x", screenPoint.x);
+        position.putDouble("y", screenPoint.y);
+        event.putMap("position", position);
+
+        return event;
+    }
+
+    public void updateExtraData(Object extraData) {
+        // if boundsToMove is not null, we now have the MapView's width/height, so we can apply
+        // a proper camera move
+        if (boundsToMove != null) {
+            HashMap<String, Float> data = (HashMap<String, Float>) extraData;
+            int width = data.get("width") == null ? 0 : data.get("width").intValue();
+            int height = data.get("height") == null ? 0 : data.get("height").intValue();
+
+            //fix for https://github.com/airbnb/react-native-maps/issues/245,
+            //it's not guaranteed the passed-in height and width would be greater than 0.
+            if (width > 0 && height > 0) {
+                double zoom = TileSystem.getBoundingBoxZoom(boundsToMove, width, height);
+                this.getController().setZoom((int) zoom);
+                this.getController().setCenter(boundsToMove.getCenter());
+                boundsToMove = null;
+            }
+        }
+    }
+
+    public void animateToRegion(BoundingBox bounds, int duration) {
+        int width = getWidth();
+        int height = getHeight();
+        if (width > 0 && height > 0) {
+            startMonitoringRegion();
+            double zoom = TileSystem.getBoundingBoxZoom(bounds, width, height);
+            double currentZoom = getZoomLevel(true);
+            double zoomDelta = Math.abs(currentZoom - zoom);
+            // TODO: made to avoid zoom 'flickering' until osmdroid 6 is released since zoom is integer
+            if (zoomDelta > 0.1) {
+                this.getController().zoomTo((int) zoom);
+            }
+            this.getController().animateTo(bounds.getCenter());
+        }
+    }
+
+    public void animateToBearing(float bearing, int duration) {
+        // TODO: animate map orientation! fallback to just setting the value
+        this.setMapOrientation(bearing);
+    }
+
+    public void animateToCoordinate(IGeoPoint coordinate, int duration) {
+        startMonitoringRegion();
+        this.getController().animateTo(coordinate);
+    }
+
+    private void fitBoundingBox(BoundingBox bounds, int padding, boolean animated) {
+        int width = getWidth() - padding * 2;
+        int height = getHeight() - padding * 2;
+        double zoom = width > 0 && height > 0
+                ? TileSystem.getBoundingBoxZoom(bounds, width, height)
+                : getMaxZoomLevel();
+        if (animated) {
+            startMonitoringRegion();
+            double currentZoom = getZoomLevel(true);
+            double zoomDelta = Math.abs(currentZoom - zoom);
+            // TODO: made to avoid zoom 'flickering' until osmdroid 6 is released since zoom is integer
+            if (zoomDelta > 0.1) {
+                this.getController().zoomTo((int) zoom);
+            }
+            this.getController().animateTo(bounds.getCenter());
+        } else {
+            this.getController().setZoom((int) zoom);
+            this.getController().setCenter(bounds.getCenter());
+        }
+    }
+
+    public void fitToElements(boolean animated) {
+
+        List<GeoPoint> points = new ArrayList<>();
+        for (OsmMapFeature feature : features) {
+            if (feature instanceof OsmMapMarker) {
+                Marker marker = (Marker) feature.getFeature();
+                points.add(marker.getPosition());
+            }
+            // TODO(lmr): may want to include shapes / etc.
+        }
+        if (points.size() > 0) {
+            BoundingBox bounds = BoundingBox.fromGeoPoints(points);
+            fitBoundingBox(bounds, this.baseMapPadding, animated);
+        }
+    }
+
+    public void fitToSuppliedMarkers(ReadableArray markerIDsArray, boolean animated) {
+        String[] markerIDs = new String[markerIDsArray.size()];
+        for (int i = 0; i < markerIDsArray.size(); i++) {
+            markerIDs[i] = markerIDsArray.getString(i);
+        }
+
+        List<String> markerIDList = Arrays.asList(markerIDs);
+
+        List<GeoPoint> points = new ArrayList<>();
+        for (OsmMapFeature feature : features) {
+            if (feature instanceof OsmMapMarker) {
+                String identifier = ((OsmMapMarker) feature).getIdentifier();
+                Marker marker = (Marker) feature.getFeature();
+                if (markerIDList.contains(identifier)) {
+                    points.add(marker.getPosition());
+                }
+            }
+        }
+
+        if (points.size() > 0) {
+            BoundingBox bounds = BoundingBox.fromGeoPoints(points);
+            fitBoundingBox(bounds, this.baseMapPadding, animated);
+        }
+    }
+
+    public void fitToCoordinates(ReadableArray coordinatesArray, ReadableMap edgePadding,
+                                 boolean animated) {
+
+        List<GeoPoint> points = new ArrayList<>();
+        for (int i = 0; i < coordinatesArray.size(); i++) {
+            ReadableMap latLng = coordinatesArray.getMap(i);
+            Double lat = latLng.getDouble("latitude");
+            Double lng = latLng.getDouble("longitude");
+            points.add(new GeoPoint(lat, lng));
+        }
+
+        if (points.size() > 0) {
+            // TODO: fix padding
+//      int left = 0;
+//      int top = 0;
+//      int right = 0;
+//      int bottom = 0;
+//      if (edgePadding != null) {
+//        left = edgePadding.getInt("left");
+//        top = edgePadding.getInt("top");
+//        right = edgePadding.getInt("right");
+//        bottom = edgePadding.getInt("bottom");
+//      }
+            BoundingBox bounds = BoundingBox.fromGeoPoints(points);
+            fitBoundingBox(bounds, this.baseMapPadding, animated);
+        }
+    }
+
+    @Override
+    public boolean dispatchTouchEvent(MotionEvent ev) {
+        scaleDetector.onTouchEvent(ev);
+        gestureDetector.onTouchEvent(ev);
+
+        int action = MotionEventCompat.getActionMasked(ev);
+
+        switch (action) {
+            case (MotionEvent.ACTION_DOWN):
+                this.getParent().requestDisallowInterceptTouchEvent(true);
+                isTouchDown = true;
+                break;
+            case (MotionEvent.ACTION_MOVE):
+                startMonitoringRegion();
+                break;
+            case (MotionEvent.ACTION_UP):
+                // Clear this regardless, since isScrollGesturesEnabled() may have been updated
+                this.getParent().requestDisallowInterceptTouchEvent(false);
+                isTouchDown = false;
+                break;
+        }
+        super.dispatchTouchEvent(ev);
+        return true;
+    }
+
+    // Timer Implementation
+
+    public void startMonitoringRegion() {
+        if (isMonitoringRegion) return;
+        timerHandler.postDelayed(timerRunnable, 100);
+        isMonitoringRegion = true;
+    }
+
+    public void stopMonitoringRegion() {
+        if (!isMonitoringRegion) return;
+        timerHandler.removeCallbacks(timerRunnable);
+        isMonitoringRegion = false;
+    }
+
+    private BoundingBox lastBoundsEmitted;
+
+    Handler timerHandler = new Handler();
+    Runnable timerRunnable = new Runnable() {
+
+        @Override
+        public void run() {
+
+            if (OsmMapView.this.isLayoutOccurred()) {
+                BoundingBox bounds = OsmMapView.this.getBoundingBox();
+
+                if ((bounds != null) &&
+                        (lastBoundsEmitted == null ||
+                                LatLngBoundsUtils.BoundsAreDifferent(bounds, lastBoundsEmitted))) {
+                    IGeoPoint center = OsmMapView.this.getMapCenter();
+                    lastBoundsEmitted = bounds;
+                    eventDispatcher.dispatchEvent(new OsmRegionChangeEvent(getId(), bounds, center, true));
+                }
+            }
+
+            timerHandler.postDelayed(this, 100);
+        }
+    };
+
+    private OsmMapMarker.OnCalloutPressListener onCalloutPressListener = new OsmMapMarker.OnCalloutPressListener() {
+        @Override
+        public void OnCalloutPress(OsmMapMarker markerView) {
+            Marker marker = (Marker) markerView.getFeature();
+
+            WritableMap event;
+            event = makeClickEventData(marker.getPosition());
+            event.putString("action", "callout-press");
+            manager.pushEvent(context, OsmMapView.this, "onCalloutPress", event);
+
+            event = makeClickEventData(marker.getPosition());
+            event.putString("action", "callout-press");
+            manager.pushEvent(context, markerView, "onCalloutPress", event);
+
+            event = makeClickEventData(marker.getPosition());
+            event.putString("action", "callout-press");
+            OsmMapCallout infoWindow = markerView.getCalloutView();
+            if (infoWindow != null) manager.pushEvent(context, infoWindow, "onPress", event);
+        }
+    };
+
+    private Marker.OnMarkerClickListener onMarkerClickListener = new Marker.OnMarkerClickListener() {
+        @Override
+        public boolean onMarkerClick(Marker marker, MapView mapView) {
+            WritableMap event;
+            OsmMapMarker airMapMarker = markerMap.get(marker);
+
+            event = makeClickEventData(marker.getPosition());
+            event.putString("action", "marker-press");
+            event.putString("id", airMapMarker.getIdentifier());
+            manager.pushEvent(context, OsmMapView.this, "onMarkerPress", event);
+
+            event = makeClickEventData(marker.getPosition());
+            event.putString("action", "marker-press");
+            event.putString("id", airMapMarker.getIdentifier());
+            manager.pushEvent(context, markerMap.get(marker), "onPress", event);
+
+            marker.showInfoWindow();
+            if (moveOnMarkerPress) {
+                mapView.getController().animateTo(marker.getPosition());
+            }
+
+            return true;
+        }
+    };
+
+    private Marker.OnMarkerDragListener onMarkerDragListener = new Marker.OnMarkerDragListener() {
+        @Override
+        public void onMarkerDragStart(Marker marker) {
+            WritableMap event = makeClickEventData(marker.getPosition());
+            manager.pushEvent(context, OsmMapView.this, "onMarkerDragStart", event);
+
+            OsmMapMarker markerView = markerMap.get(marker);
+            event = makeClickEventData(marker.getPosition());
+            manager.pushEvent(context, markerView, "onDragStart", event);
+        }
+
+        @Override
+        public void onMarkerDrag(Marker marker) {
+            WritableMap event = makeClickEventData(marker.getPosition());
+            manager.pushEvent(context, OsmMapView.this, "onMarkerDrag", event);
+
+            OsmMapMarker markerView = markerMap.get(marker);
+            event = makeClickEventData(marker.getPosition());
+            manager.pushEvent(context, markerView, "onDrag", event);
+        }
+
+        @Override
+        public void onMarkerDragEnd(Marker marker) {
+            WritableMap event = makeClickEventData(marker.getPosition());
+            manager.pushEvent(context, OsmMapView.this, "onMarkerDragEnd", event);
+
+            OsmMapMarker markerView = markerMap.get(marker);
+            event = makeClickEventData(marker.getPosition());
+            manager.pushEvent(context, markerView, "onDragEnd", event);
+        }
+    };
+
+    private Polyline.OnClickListener onPolylineClickListener = new Polyline.OnClickListener() {
+        @Override
+        public boolean onClick(Polyline polyline, MapView mapView, GeoPoint geoPoint) {
+            WritableMap event = makeClickEventData(polyline.getPoints().get(0));
+            event.putString("action", "polyline-press");
+            manager.pushEvent(context, polylineMap.get(polyline), "onPress", event);
+            return true;
+        }
+    };
+
+    public void onPanDrag(MotionEvent ev) {
+        IGeoPoint coords = this.getProjection().fromPixels((int) ev.getX(), (int) ev.getY());
+        WritableMap event = makeClickEventData(coords);
+        manager.pushEvent(context, this, "onPanDrag", event);
+    }
+
+    private InterceptDoubleTapOverlay interceptDoubleTapOverlay;
+    private InterceptScrollOverlay interceptScrollOverlay;
+    private RotationGestureOverlay mRotationGestureOverlay;
+
+    public void setScrollEnabled(boolean scrollEnabled) {
+        if (interceptScrollOverlay == null) {
+            interceptScrollOverlay = new InterceptScrollOverlay();
+            getOverlayManager().add(interceptScrollOverlay);
+        }
+        interceptScrollOverlay.setEnabled(!scrollEnabled);
+    }
+
+    public void setZoomEnabled(boolean zoomEnabled) {
+        if (interceptDoubleTapOverlay == null) {
+            interceptDoubleTapOverlay = new InterceptDoubleTapOverlay();
+            getOverlayManager().add(interceptDoubleTapOverlay);
+        }
+        interceptDoubleTapOverlay.setEnabled(!zoomEnabled);
+        setMultiTouchControls(zoomEnabled);
+    }
+
+    public void setRotateEnabled(boolean rotateEnabled) {
+        if (mRotationGestureOverlay == null) {
+            mRotationGestureOverlay = new RotationGestureOverlay(this);
+            getOverlays().add(this.mRotationGestureOverlay);
+        }
+        mRotationGestureOverlay.setEnabled(rotateEnabled);
+    }
+}

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmMapView.java
@@ -113,6 +113,52 @@ public class OsmMapView extends MapView implements MapView.OnFirstLayoutListener
         this.setTileSource(TileSourceFactory.MAPNIK);
     }
 
+    /*
+     * Disabled builtin zoom controls for good, because it does not work
+     * after view detached even if reattached to window.
+     */
+    @Override
+    @Deprecated
+    public void setBuiltInZoomControls(boolean on) {
+        super.setBuiltInZoomControls(false);
+    }
+
+    /*
+     * Keep a cache of map listeners because the original list is destroyed
+     * when view detached from window.
+     */
+    protected List<MapListener> mListnersCache = new ArrayList<>();
+
+    @Override
+    public void onAttachedToWindow() {
+        super.onAttachedToWindow();
+
+        mListners.addAll(mListnersCache);
+        mListnersCache.clear();
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        mListnersCache.addAll(mListners);
+        mListners.clear();
+
+        super.onDetachedFromWindow();
+    }
+
+    boolean m_isDestroying = false;
+    public void doDestroy() {
+        m_isDestroying = true;
+        onDetach();
+    }
+
+    @Override
+    public void onDetach() {
+        if(m_isDestroying){
+            new Exception("not an exception").printStackTrace();
+            super.onDetach();
+        }
+    }
+
     @Override
     public void onFirstLayout(View view, int i, int i1, int i2, int i3) {
         manager.pushEvent(context, this, "onMapReady", new WritableNativeMap());

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmRegionChangeEvent.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/OsmRegionChangeEvent.java
@@ -1,0 +1,50 @@
+package com.airbnb.android.react.maps.osmdroid;
+
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableNativeMap;
+import com.facebook.react.uimanager.events.Event;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.LatLngBounds;
+
+import org.osmdroid.api.IGeoPoint;
+import org.osmdroid.util.BoundingBox;
+
+public class OsmRegionChangeEvent extends Event<com.airbnb.android.react.maps.RegionChangeEvent> {
+  private final BoundingBox bounds;
+  private final IGeoPoint center;
+  private final boolean continuous;
+
+  public OsmRegionChangeEvent(int id, BoundingBox bounds, IGeoPoint center, boolean continuous) {
+    super(id);
+    this.bounds = bounds;
+    this.center = center;
+    this.continuous = continuous;
+  }
+
+  @Override
+  public String getEventName() {
+    return "topChange";
+  }
+
+  @Override
+  public boolean canCoalesce() {
+    return false;
+  }
+
+  @Override
+  public void dispatch(RCTEventEmitter rctEventEmitter) {
+
+    WritableMap event = new WritableNativeMap();
+    event.putBoolean("continuous", continuous);
+
+    WritableMap region = new WritableNativeMap();
+    region.putDouble("latitude", center.getLatitude());
+    region.putDouble("longitude", center.getLongitude());
+    region.putDouble("latitudeDelta", bounds.getLatitudeSpan());
+    region.putDouble("longitudeDelta", bounds.getLongitudeSpan());
+    event.putMap("region", region);
+
+    rctEventEmitter.receiveEvent(getViewTag(), getEventName(), event);
+  }
+}

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/overlays/InterceptDoubleTapOverlay.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/overlays/InterceptDoubleTapOverlay.java
@@ -1,0 +1,21 @@
+package com.airbnb.android.react.maps.osmdroid.overlays;
+
+import android.graphics.Canvas;
+import android.view.MotionEvent;
+
+import org.osmdroid.views.MapView;
+import org.osmdroid.views.overlay.Overlay;
+
+public class InterceptDoubleTapOverlay extends Overlay {
+
+  public InterceptDoubleTapOverlay() {
+  }
+
+  @Override public void draw(Canvas canvas, MapView mapView, boolean b) {
+  }
+
+  @Override
+  public boolean onDoubleTap(MotionEvent e, MapView mapView) {
+    return isEnabled();
+  }
+}

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/overlays/InterceptScrollOverlay.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/overlays/InterceptScrollOverlay.java
@@ -1,0 +1,21 @@
+package com.airbnb.android.react.maps.osmdroid.overlays;
+
+import android.graphics.Canvas;
+import android.view.MotionEvent;
+
+import org.osmdroid.views.MapView;
+import org.osmdroid.views.overlay.Overlay;
+
+public class InterceptScrollOverlay extends Overlay {
+
+  public InterceptScrollOverlay() {
+  }
+
+  @Override public void draw(Canvas canvas, MapView mapView, boolean b) {
+  }
+
+  @Override public boolean onScroll(MotionEvent pEvent1, MotionEvent pEvent2, float pDistanceX,
+      float pDistanceY, MapView pMapView) {
+    return isEnabled();
+  }
+}

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/utils/LatLngBoundsUtils.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/osmdroid/utils/LatLngBoundsUtils.java
@@ -1,0 +1,47 @@
+package com.airbnb.android.react.maps.osmdroid.utils;
+
+import org.osmdroid.util.BoundingBox;
+import org.osmdroid.util.GeoPoint;
+
+public class LatLngBoundsUtils {
+    public static boolean BoundsAreDifferent(BoundingBox a, BoundingBox b) {
+        GeoPoint centerA = a.getCenter();
+        double latA = centerA.getLatitude();
+        double lngA = centerA.getLongitude();
+        double latDeltaA = a.getLatitudeSpan();
+        double lngDeltaA = a.getLongitudeSpan();
+
+        GeoPoint centerB = b.getCenter();
+        double latB = centerB.getLatitude();
+        double lngB = centerB.getLongitude();
+        double latDeltaB = b.getLatitudeSpan();
+        double lngDeltaB = b.getLongitudeSpan();
+
+        double latEps = LatitudeEpsilon(a, b);
+        double lngEps = LongitudeEpsilon(a, b);
+
+        return
+                different(latA, latB, latEps) ||
+                        different(lngA, lngB, lngEps) ||
+                        different(latDeltaA, latDeltaB, latEps) ||
+                        different(lngDeltaA, lngDeltaB, lngEps);
+    }
+
+    private static boolean different(double a, double b, double epsilon) {
+        return Math.abs(a - b) > epsilon;
+    }
+
+    private static double LatitudeEpsilon(BoundingBox a, BoundingBox b) {
+        double sizeA = a.getLatitudeSpan(); // something mod 180?
+        double sizeB = b.getLatitudeSpan(); // something mod 180?
+        double size = Math.min(Math.abs(sizeA), Math.abs(sizeB));
+        return size / 2560;
+    }
+
+    private static double LongitudeEpsilon(BoundingBox a, BoundingBox b) {
+        double sizeA = a.getLongitudeSpan();
+        double sizeB = b.getLongitudeSpan();
+        double size = Math.min(Math.abs(sizeA), Math.abs(sizeB));
+        return size / 2560;
+    }
+}

--- a/lib/components/MapCallout.js
+++ b/lib/components/MapCallout.js
@@ -46,5 +46,8 @@ export default decorateMapComponent(MapCallout, {
       ios: SUPPORTED,
       android: USES_DEFAULT_IMPLEMENTATION,
     },
+    osmdroid: {
+      android: SUPPORTED,
+    },
   },
 });

--- a/lib/components/MapMarker.js
+++ b/lib/components/MapMarker.js
@@ -337,5 +337,8 @@ export default decorateMapComponent(MapMarker, {
       ios: SUPPORTED,
       android: USES_DEFAULT_IMPLEMENTATION,
     },
+    osmdroid: {
+      android: SUPPORTED,
+    },
   },
 });

--- a/lib/components/MapPolygon.js
+++ b/lib/components/MapPolygon.js
@@ -174,5 +174,8 @@ export default decorateMapComponent(MapPolygon, {
       ios: SUPPORTED,
       android: USES_DEFAULT_IMPLEMENTATION,
     },
+    osmdroid: {
+      android: SUPPORTED,
+    },
   },
 });

--- a/lib/components/MapPolyline.js
+++ b/lib/components/MapPolyline.js
@@ -170,5 +170,8 @@ export default decorateMapComponent(MapPolyline, {
       ios: SUPPORTED,
       android: USES_DEFAULT_IMPLEMENTATION,
     },
+    osmdroid: {
+      android: SUPPORTED,
+    },
   },
 });

--- a/lib/components/MapUrlTile.js
+++ b/lib/components/MapUrlTile.js
@@ -71,5 +71,8 @@ export default decorateMapComponent(MapUrlTile, {
       ios: SUPPORTED,
       android: USES_DEFAULT_IMPLEMENTATION,
     },
+    osmdroid: {
+      android: SUPPORTED,
+    },
   },
 });

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -61,6 +61,7 @@ const propTypes = {
    */
   provider: PropTypes.oneOf([
     'google',
+    'osmdroid',
   ]),
 
   /**
@@ -795,6 +796,7 @@ const airMaps = {
 };
 if (Platform.OS === 'android') {
   airMaps.google = airMaps.default;
+  airMaps.osmdroid = nativeComponent('OsmMap');
 } else {
   airMaps.google = googleMapIsInstalled ? nativeComponent('AIRGoogleMap') :
     createNotSupportedComponent('react-native-maps: AirGoogleMaps dir must be added to your xCode project to support GoogleMaps on iOS.'); // eslint-disable-line max-len

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -24,6 +24,7 @@ import {
   contextTypes as childContextTypes,
   getAirMapName,
   googleMapIsInstalled,
+  osmdroidIsInstalled,
   createNotSupportedComponent,
 } from './decorateMapComponent';
 import * as ProviderConstants from './ProviderConstants';
@@ -796,7 +797,8 @@ const airMaps = {
 };
 if (Platform.OS === 'android') {
   airMaps.google = airMaps.default;
-  airMaps.osmdroid = nativeComponent('OsmMap');
+  airMaps.osmdroid = osmdroidIsInstalled ? nativeComponent('OsmMap') :
+    createNotSupportedComponent('react-native-maps: osmdroid dependecy must be added to your app build.gradle to support osmdroid provider.'); // eslint-disable-line max-len
 } else {
   airMaps.google = googleMapIsInstalled ? nativeComponent('AIRGoogleMap') :
     createNotSupportedComponent('react-native-maps: AirGoogleMaps dir must be added to your xCode project to support GoogleMaps on iOS.'); // eslint-disable-line max-len

--- a/lib/components/ProviderConstants.js
+++ b/lib/components/ProviderConstants.js
@@ -1,2 +1,3 @@
 export const PROVIDER_DEFAULT = null;
 export const PROVIDER_GOOGLE = 'google';
+export const PROVIDER_OSMDROID = 'osmdroid';

--- a/lib/components/decorateMapComponent.js
+++ b/lib/components/decorateMapComponent.js
@@ -7,6 +7,7 @@ import {
 import {
   PROVIDER_DEFAULT,
   PROVIDER_GOOGLE,
+  PROVIDER_OSMDROID,
 } from './ProviderConstants';
 
 export const SUPPORTED = 'SUPPORTED';
@@ -14,6 +15,7 @@ export const USES_DEFAULT_IMPLEMENTATION = 'USES_DEFAULT_IMPLEMENTATION';
 export const NOT_SUPPORTED = 'NOT_SUPPORTED';
 
 export function getAirMapName(provider) {
+  if (Platform.OS === 'android' && provider === PROVIDER_OSMDROID) return 'OsmMap';
   if (Platform.OS === 'android') return 'AIRMap';
   if (provider === PROVIDER_GOOGLE) return 'AIRGoogleMap';
   return 'AIRMap';

--- a/lib/components/decorateMapComponent.js
+++ b/lib/components/decorateMapComponent.js
@@ -35,6 +35,7 @@ export const createNotSupportedComponent = message => () => {
 };
 
 export const googleMapIsInstalled = !!NativeModules.UIManager[getAirMapName(PROVIDER_GOOGLE)];
+export const osmdroidIsInstalled = !!NativeModules.UIManager[getAirMapName(PROVIDER_OSMDROID)];
 
 export default function decorateMapComponent(Component, { componentType, providers }) {
   const components = {};


### PR DESCRIPTION
### Does any other open PR do the same thing?
No

### What issue is this PR fixing?
This is not a fix, but is related to various enhancement requests opened from time to time to avoid using/depending on Google Maps and Google Play Services, licensing issues etc.

My motivation is: we started replacing Google maps by osmdroid on my company Android apps, but there is no solution ready to use with react-native, I could develop a new lib, and handle all issues related to multi platform, etc, or enhance an existing lib.

### How did you test this PR?
I have apps in production using this code. I also run the example project and could use most of it using the proposed osmdroid provider. Actually, I used the example project to debug and develop various details I didn't use on my apps.

I am using this very code in production, but probably this branch is not in the best option to just merge in master. I hope we can at least start a discussion on how to integrate this officially on the lib.

What is included: 
 - MapView: working with some limitations like no map styles.
 - Markers: most of it working, except the color for default markers and z-index.
 - Callouts: working. Needed some hacks as result of how it is implemented on osmdroid vs my lack of knowledge on react-native internals.
 - Polygons, working except for z-index and geodesic prop.
 - Polylines, working except for z-index and geodesic prop.

The native code is almost all contained on 'com.airbnb.android.react.maps.osmdroid' package. The only exception is com.airbnb.android.react.maps.MapsPackage that exports this provider classes, but only when osmdroid is included in the classpath. Osmdroid lib is included as a compileOnly dependency.

Cheers