### PR TITLE
[iOS] Fix coordinateForPoint returns nothing (Google Maps)

### DIFF
--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -696,7 +696,15 @@ class MapView extends React.Component {
     if (Platform.OS === 'android') {
       return NativeModules.AirMapModule.coordinateForPoint(this._getHandle(), point);
     } else if (Platform.OS === 'ios') {
-      return this._runCommand('coordinateForPoint', [point]);
+      return new Promise((resolve, reject) => {
+        this._runCommand('coordinateForPoint', [point, (err, res) => {
+          if (err) {
+            reject(err)
+          } else {
+            resolve(res)
+          }
+        }]);
+      })
     }
     return Promise.reject('coordinateForPoint not supported on this platform');
   }

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -695,7 +695,8 @@ class MapView extends React.Component {
   coordinateForPoint(point) {
     if (Platform.OS === 'android') {
       return NativeModules.AirMapModule.coordinateForPoint(this._getHandle(), point);
-    } else if (Platform.OS === 'ios') {
+    } else if (Platform.OS === 'ios' && this.props.provider
+      && this.props.provider === ProviderConstants.PROVIDER_GOOGLE) {
       return new Promise((resolve, reject) => {
         this._runCommand('coordinateForPoint', [point, (err, res) => {
           if (err) {
@@ -705,6 +706,8 @@ class MapView extends React.Component {
           }
         }]);
       })
+    } else if (Platform.OS === 'ios') {
+      return this._runCommand('coordinateForPoint', [point])
     }
     return Promise.reject('coordinateForPoint not supported on this platform');
   }


### PR DESCRIPTION
https://github.com/react-community/react-native-maps/pull/2039
this PR is not suitable for iOS Google Maps

### What issue is this PR fixing?

1) The absence of returned Promise
2) `AIRGoogleMapManager.coordinateForPoint was called with 2 arguments but expects 3 arguments. If you haven't changed this method yourself, this usually means that your versions of the native code and JavaScript code are out of sync. Updating both should make this error go away.`

### How did you test this PR?

Affects the only iOS, works fine both for Google Maps and Apple Maps