### PR TITLE
[iOS Google Maps] Fix update camera always animated

### DIFF
--- a/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -191,7 +191,13 @@ RCT_EXPORT_METHOD(fitToElements:(nonnull NSNumber *)reactTag
       for (AIRGoogleMapMarker *marker in mapView.markers)
         bounds = [bounds includingCoordinate:marker.realMarker.position];
 
-      [mapView animateWithCameraUpdate:[GMSCameraUpdate fitBounds:bounds withPadding:55.0f]];
+      GMSCameraUpdate *cameraUpdate = [GMSCameraUpdate fitBounds:bounds withPadding:55.0f];
+
+      if (animated) {
+        [mapView animateWithCameraUpdate: cameraUpdate];
+      } else {
+        [mapView moveCamera: cameraUpdate];
+      }
     }
   }];
 }
@@ -220,7 +226,13 @@ RCT_EXPORT_METHOD(fitToSuppliedMarkers:(nonnull NSNumber *)reactTag
       for (AIRGoogleMapMarker *marker in filteredMarkers)
         bounds = [bounds includingCoordinate:marker.realMarker.position];
 
-      [mapView animateWithCameraUpdate:[GMSCameraUpdate fitBounds:bounds withPadding:55.0f]];
+      GMSCameraUpdate *cameraUpdate = [GMSCameraUpdate fitBounds:bounds withPadding:55.0f];
+
+      if (animated) {
+        [mapView animateWithCameraUpdate: cameraUpdate];
+      } else {
+        [mapView moveCamera: cameraUpdate];
+      }
     }
   }];
 }
@@ -249,7 +261,13 @@ RCT_EXPORT_METHOD(fitToCoordinates:(nonnull NSNumber *)reactTag
       CGFloat bottom = [RCTConvert CGFloat:edgePadding[@"bottom"]];
       CGFloat left = [RCTConvert CGFloat:edgePadding[@"left"]];
 
-      [mapView animateWithCameraUpdate:[GMSCameraUpdate fitBounds:bounds withEdgeInsets:UIEdgeInsetsMake(top, left, bottom, right)]];
+      GMSCameraUpdate *cameraUpdate = [GMSCameraUpdate fitBounds:bounds withEdgeInsets:UIEdgeInsetsMake(top, left, bottom, right)];
+
+      if (animated) {
+        [mapView animateWithCameraUpdate: cameraUpdate];
+      } else {
+        [mapView moveCamera: cameraUpdate];
+      }
     }
   }];
 }


### PR DESCRIPTION
### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

iOS GoogleMap update camera always animated.
`fitToElements`, `fitToSuppliedMarkers` and `fitToCoordinates` has `animated` parameter but real implantation ignore this parameter, always call `animateWithCameraUpdate`.

### How did you test this PR?

run on iOS simulator (iOS 11.4)
