### PR TITLE
Tweaked AirMapUrlTile to allow for 512 tile size

### DIFF
--- a/lib/ios/AirMaps/AIRMapUrlTile.m
+++ b/lib/ios/AirMaps/AIRMapUrlTile.m
@@ -60,6 +60,7 @@
     if (self.maximumZ) {
         self.tileOverlay.maximumZ = self.maximumZ;
     }
+    self.tileOverlay.tileSize = CGSizeMake(512, 512);
     self.renderer = [[MKTileOverlayRenderer alloc] initWithTileOverlay:self.tileOverlay];
 }
 


### PR DESCRIPTION
### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

https://github.com/react-community/react-native-maps/issues/2567

### How did you test this PR?

1. Took snapshots of what the map looked like before this fix, outlined in the issue above.
2. Tested that new map displays tiles correctly on an iPhone SE device running iOS 12. 

This change affects iOS/Apple Maps only.