### PR TITLE
Calculate bounding box from region

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -237,6 +237,7 @@ declare module "react-native-maps" {
         fitToSuppliedMarkers(markers: string[], options?: { edgePadding?: EdgePadding, animated?: boolean }): void;
         fitToCoordinates(coordinates?: LatLng[], options?: { edgePadding?: EdgePadding, animated?: boolean }): void;
         setMapBoundaries(northEast: LatLng, southWest: LatLng): void;
+        getMapBoundaries(): {northEast: LatLng; southWest: LatLng};
         takeSnapshot(options?: SnapshotOptions): Promise<string>;
     }
 

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -665,9 +665,9 @@ class MapView extends React.Component {
    */
   async getMapBoundaries() {
     if (Platform.OS === 'android') {
-      return NativeModules.AirMapModule.getMapBoundaries(this._getHandle());
+      return await NativeModules.AirMapModule.getMapBoundaries(this._getHandle());
     } else if (Platform.OS === 'ios') {
-      return this._runCommand('getMapBoundaries', []);
+      return await this._runCommand('getMapBoundaries', []);
     }
     return Promise.reject('getMapBoundaries not supported on this platform');
   }

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -791,6 +791,26 @@ class MapView extends React.Component {
     return Promise.reject('coordinateForPoint not supported on this platform');
   }
 
+  /**
+   * Get bounding box from region
+   *
+   * @param region Region
+   *
+   * @return Object Object bounding box ({ northEast: <LatLng>, southWest: <LatLng> })
+   */
+  boundingBoxForRegion(region) {
+    return {
+      northEast: {
+        latitude: region.latitude + region.latitudeDelta / 2,
+        longitude: region.longitude + region.longitudeDelta / 2,
+      },
+      southWest: {
+        latitude: region.latitude - region.latitudeDelta / 2,
+        longitude: region.longitude - region.longitudeDelta / 2,
+      },
+    };
+  }
+
   _uiManagerCommand(name) {
     return NativeModules.UIManager[getAirMapName(this.props.provider)].Commands[name];
   }

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -801,12 +801,12 @@ class MapView extends React.Component {
   boundingBoxForRegion(region) {
     return {
       northEast: {
-        latitude: region.latitude + region.latitudeDelta / 2,
-        longitude: region.longitude + region.longitudeDelta / 2,
+        latitude: region.latitude + (region.latitudeDelta / 2),
+        longitude: region.longitude + (region.longitudeDelta / 2),
       },
       southWest: {
-        latitude: region.latitude - region.latitudeDelta / 2,
-        longitude: region.longitude - region.longitudeDelta / 2,
+        latitude: region.latitude - (region.latitudeDelta / 2),
+        longitude: region.longitude - (region.longitudeDelta / 2),
       },
     };
   }

--- a/lib/ios/AirMaps/AIRMapManager.m
+++ b/lib/ios/AirMaps/AIRMapManager.m
@@ -939,7 +939,7 @@ static int kDragCenterContext;
 - (void)mapViewWillStartRenderingMap:(AIRMap *)mapView
 {
     if (!mapView.hasStartedRendering) {
-      mapView.onMapReady(@{}); 
+      mapView.onMapReady(@{});
       mapView.hasStartedRendering = YES;
     }
     [mapView beginLoading];


### PR DESCRIPTION
### Does any other open PR do the same thing?

No

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

### What issue is this PR fixing?

This PR extends by previous PR https://github.com/react-native-community/react-native-maps/pull/2571 based on disscussion which starts here https://github.com/react-native-community/react-native-maps/pull/2571#issuecomment-440993046

This PR just brings helper method which calculates bounding box from region, because it is much faster than accessing native module. But could be used only in some cases when is region available.

### How did you test this PR?

You can see screenshots in this comments, https://github.com/react-native-community/react-native-maps/pull/2571#issuecomment-440956375 where is comparison native vs react side.

<!--
Thanks for your contribution :)
-->