### PR TITLE
Defaults to the map services version instead of play services

### DIFF
--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -47,7 +47,7 @@ android {
 dependencies {
   def googlePlayServicesVersion = safeExtGet('googlePlayServicesVersion', DEFAULT_GOOGLE_PLAY_SERVICES_VERSION)
   // Variable lookup order : googlePlayServicesMapsVersion > googlePlayServicesVersion > DEFAULT_GOOGLE_PLAY_SERVICES_MAPS_VERSION
-  def googlePlayServicesMapsVersion = safeExtGet('googlePlayServicesMapsVersion', safeExtGet('googlePlayServicesVersion', DEFAULT_GOOGLE_PLAY_SERVICES_VERSION))
+  def googlePlayServicesMapsVersion = safeExtGet('googlePlayServicesMapsVersion', safeExtGet('googlePlayServicesVersion', DEFAULT_GOOGLE_PLAY_SERVICES_MAPS_VERSION))
   def androidMapsUtilsVersion = safeExtGet('androidMapsUtilsVersion', DEFAULT_ANDROID_MAPS_UTILS_VERSION)
 
   compileOnly "com.facebook.react:react-native:+"


### PR DESCRIPTION
As of now the googlePlayServicesMapsVersion variable defaults to "DEFAULT_GOOGLE_PLAY_SERVICES_VERSION" which is an unpublished version of maps - 16. 0.1, it needs to default to "DEFAULT_GOOGLE_PLAY_SERVICES_MAPS_VERSION" instead which is 16.0.0

### Does any other open PR do the same thing?

No, no other PR's have been submitted at the time of writing.

### What issue is this PR fixing?

https://github.com/react-native-community/react-native-maps/issues/2652

### How did you test this PR?

Ran the sync before and after fixing with it symlinked, my PR fixes the issue with downloading the correct play services version.
