### PR TITLE
Fix warning in RN >= 0.58

### DIFF
--- a/lib/components/decorateMapComponent.js
+++ b/lib/components/decorateMapComponent.js
@@ -32,7 +32,17 @@ export const createNotSupportedComponent = message => () => {
   return null;
 };
 
-export const googleMapIsInstalled = !!NativeModules.UIManager[getAirMapName(PROVIDER_GOOGLE)];
+function getViewManagerConfig(viewManagerName) {
+  const UIManager = NativeModules.UIManager;
+  if (!UIManager.getViewManagerConfig) {
+    // RN < 0.58
+    return UIManager[viewManagerName];
+  }
+  // RN >= 0.58
+  return UIManager.getViewManagerConfig(viewManagerName);
+}
+
+export const googleMapIsInstalled = !!getViewManagerConfig(getAirMapName(PROVIDER_GOOGLE));
 
 export default function decorateMapComponent(Component, { componentType, providers }) {
   const components = {};
@@ -70,8 +80,8 @@ export default function decorateMapComponent(Component, { componentType, provide
   };
 
   Component.prototype.getUIManagerCommand = function getUIManagerCommand(name) {  // eslint-disable-line no-param-reassign,max-len
-    return NativeModules.UIManager[getAirComponentName(this.context.provider, componentType)]
-      .Commands[name];
+    const componentName = getAirComponentName(this.context.provider, componentType);
+    return getViewManagerConfig(componentName).Commands[name];
   };
 
   Component.prototype.getMapManagerCommand = function getMapManagerCommand(name) { // eslint-disable-line no-param-reassign,max-len


### PR DESCRIPTION
fixes #2620 YellowBox warning on react-native 0.58.0-rc.1

### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

#2620

### How did you test this PR?

1. Update ios application that use react-native-maps to react-native 0.58.0-rc.3
2. Open screen with any map component
3. Check that no warning after this PR applied
