### PR TITLE
Implement 'tappable' prop on polyline for Android

### DIFF
--- a/docs/polygon.md
+++ b/docs/polygon.md
@@ -15,7 +15,7 @@
 | `geodesic` | `Boolean` |  | Boolean to indicate whether to draw each segment of the line as a geodesic as opposed to straight lines on the Mercator projection. A geodesic is the shortest path between two points on the Earth's surface. The geodesic curve is constructed assuming the Earth is a sphere.
 | `lineDashPhase` | `Number` | `0` | (iOS only) The offset (in points) at which to start drawing the dash pattern. Use this property to start drawing a dashed line partway through a segment or gap. For example, a phase value of 6 for the patter 5-2-3-2 would cause drawing to begin in the middle of the first gap.
 | `lineDashPattern` | `Array<Number>` | `null` | (iOS only) An array of numbers specifying the dash pattern to use for the path. The array contains one or more numbers that indicate the lengths (measured in points) of the  line segments and gaps in the pattern. The values in the array alternate, starting with the first line segment length, followed by the first gap length, followed by the second line segment length, and so on.
-| `tappable` | `Bool` | false (for iOS) | Boolean to allow a polygon to be tappable and use the onPress function.
+| `tappable` | `Bool` | false | Boolean to allow a polygon to be tappable and use the onPress function.
 
 ## Events
 

--- a/docs/polyline.md
+++ b/docs/polyline.md
@@ -14,6 +14,7 @@
 | `geodesic` | `Boolean` |  | Boolean to indicate whether to draw each segment of the line as a geodesic as opposed to straight lines on the Mercator projection. A geodesic is the shortest path between two points on the Earth's surface. The geodesic curve is constructed assuming the Earth is a sphere.
 | `lineDashPhase` | `Number` | `0` | (iOS only) The offset (in points) at which to start drawing the dash pattern. Use this property to start drawing a dashed line partway through a segment or gap. For example, a phase value of 6 for the patter 5-2-3-2 would cause drawing to begin in the middle of the first gap.
 | `lineDashPattern` | `Array<Number>` | `null` | (iOS only) An array of numbers specifying the dash pattern to use for the path. The array contains one or more numbers that indicate the lengths (measured in points) of the  line segments and gaps in the pattern. The values in the array alternate, starting with the first line segment length, followed by the first gap length, followed by the second line segment length, and so on.
+| `tappable` | `Bool` | false | Boolean to allow a polyline to be tappable and use the onPress function.
 
 ## Events
 

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapPolyline.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapPolyline.java
@@ -22,6 +22,7 @@ public class AirMapPolyline extends AirMapFeature {
   private List<LatLng> coordinates;
   private int color;
   private float width;
+  private boolean tappable;
   private boolean geodesic;
   private float zIndex;
   private Cap lineCap = new RoundCap();
@@ -60,6 +61,13 @@ public class AirMapPolyline extends AirMapFeature {
     this.zIndex = zIndex;
     if (polyline != null) {
       polyline.setZIndex(zIndex);
+    }
+  }
+
+  public void setTappable(boolean tapabble) {
+    this.tappable = tapabble;
+    if (polyline != null) {
+      polyline.setClickable(tappable);
     }
   }
 
@@ -105,7 +113,7 @@ public class AirMapPolyline extends AirMapFeature {
   @Override
   public void addToMap(GoogleMap map) {
     polyline = map.addPolyline(getPolylineOptions());
-    polyline.setClickable(true);
+    polyline.setClickable(this.tappable);
   }
 
   @Override

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapPolylineManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapPolylineManager.java
@@ -62,6 +62,11 @@ public class AirMapPolylineManager extends ViewGroupManager<AirMapPolyline> {
     view.setColor(color);
   }
 
+  @ReactProp(name = "tappable", defaultBoolean = false)
+  public void setTappable(AirMapPolyline view, boolean tapabble) {
+    view.setTappable(tapabble);
+  }
+
   @ReactProp(name = "geodesic", defaultBoolean = false)
   public void setGeodesic(AirMapPolyline view, boolean geodesic) {
     view.setGeodesic(geodesic);


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

No

### What issue is this PR fixing?

Fixes #2591 

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

1. Create a `Polyline` and tap on it on Android.
2. Observe `onPress` event from Map.
3. Add `tappable` prop to `Polyline`.
4. Observe lack of `onPress` event from Map.

<!--
Thanks for your contribution :)
-->
