### PR TITLE
Extend onPanDrag()

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -167,6 +167,14 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
             }
             return false;
           }
+
+          @Override
+          public boolean onDoubleTap(MotionEvent e) {
+            if (handlePanDrag) {
+              onPanDrag(e);
+            }
+            return false;
+          }
         });
 
     this.addOnLayoutChangeListener(new OnLayoutChangeListener() {
@@ -903,6 +911,10 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
   @Override
   public boolean dispatchTouchEvent(MotionEvent ev) {
     gestureDetector.onTouchEvent(ev);
+
+    if (handlePanDrag && ev.getPointerCount() > 1) {
+      onPanDrag(ev);
+    }
 
     int action = MotionEventCompat.getActionMasked(ev);
 

--- a/lib/ios/AirMaps/AIRMap.m
+++ b/lib/ios/AirMaps/AIRMap.m
@@ -265,7 +265,12 @@ const NSInteger AIRMapMaxZoomLevel = 20;
     for (UIGestureRecognizer *recognizer in [self gestureRecognizers]) {
         if ([recognizer isKindOfClass:[UIPanGestureRecognizer class]]) {
             recognizer.enabled = handleMapDrag;
-            break;
+        }
+        if ([recognizer isKindOfClass:[UIRotationGestureRecognizer class]]) {
+            recognizer.enabled = handleMapDrag;
+        }
+        if ([recognizer isKindOfClass:[UIPinchGestureRecognizer class]]) {
+            recognizer.enabled = handleMapDrag;
         }
     }
 }

--- a/lib/ios/AirMaps/AIRMapManager.m
+++ b/lib/ios/AirMaps/AIRMapManager.m
@@ -68,6 +68,8 @@ RCT_EXPORT_MODULE()
 
     // disable drag by default
     drag.enabled = NO;
+    rotate.enabled = NO;
+    pinch.enabled = NO;
     
     pinch.delegate = self;
     rotate.delegate = self;
@@ -1228,7 +1230,7 @@ static int kDragCenterContext;
 }
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
-    return true;
+    return YES;
 }
 
 @end


### PR DESCRIPTION
### Does any other open PR do the same thing?
https://github.com/react-native-community/react-native-maps/pull/2314 also solves an issue with pan dragging.

### What issue is this PR fixing?
In our app we wanted to extend the behavior of onPandrag to include zoom, rotate and pinch and fix an issue with the gesture recognizer on iOS.

For now I've included them in the onPandrag event, ideally this should become an onZoom and onPinch. For both Android and iOS I wonder if these gesture recognizers are the correct approach, if so I will implement onZoom and onPinch.

### How did you test this PR?

- [ ] Create a map component with onPandrag
- [ ] Pinch, Zoom and Drag, onPandrag should fire
- [ ] onPanDrag should now also fire when scrollEnabled=true

#### **Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?**
iOS (Apple Maps) + Android
#### **Did you test this on a real device, or in a simulator?**
Both