### PR TITLE
Enable RN projects to define the Android AppCompat Library version (and fix dependency issues with RN 0.59 RC)

### DIFF
--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -4,6 +4,7 @@ apply from: 'gradle-maven-push.gradle'
 def DEFAULT_COMPILE_SDK_VERSION               = 27
 def DEFAULT_BUILD_TOOLS_VERSION               = "27.0.3"
 def DEFAULT_TARGET_SDK_VERSION                = 27
+def DEFAULT_ANDROID_SUPPORT_LIB_VERSION       = "27.0.2"
 def DEFAULT_GOOGLE_PLAY_SERVICES_VERSION      = "16.0.1"
 def DEFAULT_GOOGLE_PLAY_SERVICES_MAPS_VERSION = "16.0.0"
 def DEFAULT_ANDROID_MAPS_UTILS_VERSION        = "0.5+"
@@ -45,12 +46,14 @@ android {
 }
 
 dependencies {
+  def supportLibVersion = safeExtGet('supportLibVersion', DEFAULT_ANDROID_SUPPORT_LIB_VERSION)
   def googlePlayServicesVersion = safeExtGet('googlePlayServicesVersion', DEFAULT_GOOGLE_PLAY_SERVICES_VERSION)
   // Variable lookup order : googlePlayServicesMapsVersion > googlePlayServicesVersion > DEFAULT_GOOGLE_PLAY_SERVICES_MAPS_VERSION
   def googlePlayServicesMapsVersion = safeExtGet('googlePlayServicesMapsVersion', safeExtGet('googlePlayServicesVersion', DEFAULT_GOOGLE_PLAY_SERVICES_MAPS_VERSION))
   def androidMapsUtilsVersion = safeExtGet('androidMapsUtilsVersion', DEFAULT_ANDROID_MAPS_UTILS_VERSION)
 
   compileOnly "com.facebook.react:react-native:+"
+  implementation "com.android.support:appcompat-v7:$supportLibVersion"
   implementation "com.google.android.gms:play-services-base:$googlePlayServicesVersion"
   implementation "com.google.android.gms:play-services-maps:$googlePlayServicesMapsVersion"
   implementation "com.google.maps.android:android-maps-utils:$androidMapsUtilsVersion"


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

No

### What issue is this PR fixing?

Issue #2695, a problem with the upcoming version of react-native. This should also work with all previous versions of RN.

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

- Use a RN 0.58.x project with react-native-webview which works fine.
- Update RN to 0.59.0-rc.2. This new version has some other gradle depencies and use Android 28 as build tool. Some other changes are also required, a [complete diff is available here](https://github.com/jerolimov/react-native-init-history/compare/0.58.3...4daf7fe0a996259aca633e17ad6747ae33dc1308).
- The build breaks with only updating RN.
- The build works again with applying this change. (My project uses supportLibVersion = "28.0.0")

<!--
Thanks for your contribution :)
-->

### Test this PR before it got merged

You can test it with your project by installing this branch directly from GitHub:

`npm install --save "react-native-maps@jerolimov/react-native-maps#fix-rn59rc-compile-issues"`

or

`yarn add "react-native-maps@jerolimov/react-native-maps#fix-rn59rc-compile-issues"`

Remember to switch back to the official releases as soon as possible. 😏 