### PR TITLE
Add Marker icon property introduced in #2650 to index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -254,6 +254,7 @@ declare module "react-native-maps" {
         title?: string;
         description?: string;
         image?: ImageURISource | ImageRequireSource;
+        icon?: ImageURISource | ImageRequireSource;
         opacity?: number;
         pinColor?: string;
         coordinate: LatLng | AnimatedRegion;


### PR DESCRIPTION
### Does any other open PR do the same thing?

No.

### What issue is this PR fixing?

With TypeScript, trying to use the Marker's icon property results in an error, since the `index.d.ts` does not yet declare the property that was added in #2650.

### How did you test this PR?

Tested by editing the `index.d.ts` locally. Since there are no functional changes, this is a trivial change.