### PR TITLE
Include gradle-maven-push only when props are set

### DIFF
--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: 'com.android.library'
-apply from: 'gradle-maven-push.gradle'
+if (project.hasProperty('POM_ARTIFACT_ID')) {
+  apply from: 'gradle-maven-push.gradle'
+}
 
 android {
   compileSdkVersion rootProject.ext.compileSdkVersion


### PR DESCRIPTION
This fixes a build error seen in app projects if the properties are not set.
I missed to include this in #2720

The gradle-maven-push.gradle script is only needed when publishing artifacts to a maven repository. It is *not* needed for apps consuming the library (and should not be included).

### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

Issue reported by @grifotv in #2720

### How did you test this PR?

- Create a new project using `react-native init` and follow `react-native-maps` integration steps
- Use different dependencies in `package.json`:

| Dependency | Result |
| -- | -- |
| `"react-native-maps": "^0.23.0"` | ✔️ Success |
| `"react-native-maps": "react-native-community/react-native-maps"` | 🔴 Failure |
| `"react-native-maps": "friederbluemle/react-native-maps#fix-gradle-build"` | ✔️ **Success** |