### PR TITLE
Add appcompat-v7 dependency declaration to lib

### DIFF
--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -3,12 +3,16 @@ if (project.hasProperty('POM_ARTIFACT_ID')) {
   apply from: 'gradle-maven-push.gradle'
 }
 
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-  compileSdkVersion rootProject.ext.compileSdkVersion
+  compileSdkVersion safeExtGet('compileSdkVersion', 28)
 
   defaultConfig {
-    minSdkVersion rootProject.ext.minSdkVersion
-    targetSdkVersion rootProject.ext.targetSdkVersion
+    minSdkVersion safeExtGet('minSdkVersion', 16)
+    targetSdkVersion safeExtGet('targetSdkVersion', 27)
   }
 }
 
@@ -16,6 +20,7 @@ dependencies {
   compileOnly('com.facebook.react:react-native:+') {
     exclude group: 'com.android.support'
   }
+  implementation "com.android.support:appcompat-v7:${safeExtGet('supportLibVersion', '28.0.0')}"
   implementation 'com.google.android.gms:play-services-base:16.1.0'
   implementation 'com.google.android.gms:play-services-maps:16.1.0'
   implementation 'com.google.maps.android:android-maps-utils:0.5'


### PR DESCRIPTION
### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

Some people have reported dependency issues with the Android support libraries (see #2695, #2720). The reason is a version conflict that Gradle alone can't resolve. Without explicit declaration, Gradle will use the transitive dependency (`26.0.1` from `play-services-base:16.1.0`). By explicit declaration it is possible to use other versions too.

This PR adds back the `appcompat-v7` dependency (even though the library has no dependencies on it) which was removed in #2720

Also (re-)added the conventional `safeExtGet` function seen in many other RN library projects.

### How did you test this PR?

Tested using the example project.

Step 1: Remove `appcompat-v7` dependency from example (The project has no dependency on `appcompat-v7`!)
Step 2: See project build fail. The reason is RN `0.54.2` which has a compile dependency on `appcompat-v7:23.0.1`.
Step 3: Workaround fix for example project:
```
    implementation('com.facebook.react:react-native:+') {
        exclude group: 'com.android.support', module: 'support-v4'
    }
```
This will prevent Gradle from picking the wrong `23.0.1` version of `support-v4`. The latest version of RN will set it to `28.0.0`.
Step 4: Example project builds!