### PR TITLE
Android: Allow setting of play-services version through ext

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,8 @@ buildscript {
     minSdkVersion = 16
     compileSdkVersion = 28
     targetSdkVersion = 27
-    supportLibVersion = "28.0.0"
+    supportLibVersion = '28.0.0'
+    playServicesVersion = '16.1.0'
   }
   repositories {
     google()

--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     exclude group: 'com.android.support'
   }
   implementation "com.android.support:appcompat-v7:${safeExtGet('supportLibVersion', '28.0.0')}"
-  implementation 'com.google.android.gms:play-services-base:16.1.0'
-  implementation 'com.google.android.gms:play-services-maps:16.1.0'
+  implementation "com.google.android.gms:play-services-base:${safeExtGet('playServicesVersion', '16.1.0')}"
+  implementation "com.google.android.gms:play-services-maps:${safeExtGet('playServicesVersion', '16.1.0')}"
   implementation 'com.google.maps.android:android-maps-utils:0.5'
 }


### PR DESCRIPTION
### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

Allows the `play-services-*` dependencies versions to be set externally again. Something that was accidentally removed in #2720 

Version defaults to `16.1.0`.

### How did you test this PR?

Building the sample app, and changing the version.