### PR TITLE
fix func 'randomColor' in DefaultMarkers.js

### DIFF
--- a/example/examples/DefaultMarkers.js
+++ b/example/examples/DefaultMarkers.js
@@ -19,7 +19,12 @@ const LONGITUDE_DELTA = LATITUDE_DELTA * ASPECT_RATIO;
 let id = 0;
 
 function randomColor() {
-  return `#${Math.floor(Math.random() * 16777215).toString(16)}`;
+    var ret = `${Math.floor(Math.random() * 16777215).toString(16)}`;
+    while (ret.length < 6) {
+        ret = '0' + ret;
+    }
+    ret = '#' + ret;
+    return ret;
 }
 
 class DefaultMarkers extends React.Component {


### PR DESCRIPTION
### Does any other open PR do the same thing?

No.

### What issue is this PR fixing?

The previous randomColor function may return invalid color string, like "#12345", which length is not valid. This may generate warning messages in the example page.
The new one fills the string with zeros, like "#012345" in the previous example.

### How did you test this PR?

I use this function to generate many colors randomly, and check if every color string is valid.

After the change, when I click many times to add markers to the map, the warning no longer appears.