### PR TITLE
[GoogleMaps] Update podspec to use GoogleMaps 3.0.3

### DIFF
--- a/example/ios/AirMapsExplorer.xcodeproj/project.pbxproj
+++ b/example/ios/AirMapsExplorer.xcodeproj/project.pbxproj
@@ -451,6 +451,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 				);
 				INFOPLIST_FILE = AirMapsExplorer/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = AirMapsExplorer;
@@ -473,6 +474,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 				);
 				INFOPLIST_FILE = AirMapsExplorer/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = AirMapsExplorer;

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -22,16 +22,16 @@ PODS:
     - GoogleMaps
   - Google-Maps-iOS-Utils/QuadTree (2.1.0):
     - GoogleMaps
-  - GoogleMaps (2.5.0):
-    - GoogleMaps/Maps (= 2.5.0)
-  - GoogleMaps/Base (2.5.0)
-  - GoogleMaps/Maps (2.5.0):
+  - GoogleMaps (3.0.3):
+    - GoogleMaps/Maps (= 3.0.3)
+  - GoogleMaps/Base (3.0.3)
+  - GoogleMaps/Maps (3.0.3):
     - GoogleMaps/Base
   - React (0.59.3):
     - React/Core (= 0.59.3)
   - react-native-google-maps (0.24.0):
     - Google-Maps-iOS-Utils (= 2.1.0)
-    - GoogleMaps (= 2.5.0)
+    - GoogleMaps (= 3.0.3)
     - React
   - react-native-maps (0.24.0):
     - React
@@ -141,10 +141,10 @@ SPEC CHECKSUMS:
   Folly: de497beb10f102453a1afa9edbf8cf8a251890de
   glog: aefd1eb5dda2ab95ba0938556f34b98e2da3a60d
   Google-Maps-iOS-Utils: c32891ff472eaaa1fca032beedafa1a013af7875
-  GoogleMaps: c087b8e5dfe87ca6ebf59adb9b4894a4146bec4f
+  GoogleMaps: fd5c9fa58871781b9fb94d4936f19c69fe60ce32
   React: b52fdb80565505b7e4592b313a38868f5df51641
-  react-native-google-maps: dd3cee2ea5d77ffba4f03b1fd64891e5113b3193
-  react-native-maps: 7525a32bcd025af8cf3b6c469af9b8758245db72
+  react-native-google-maps: 6142058c902e207524e1d92277d749cf9e2c3bd7
+  react-native-maps: d87d8ed456d4132112fb1d2ee9baf3470c0f211d
   yoga: 1a492113f66a35e9e583bb0434f4b8cc668dd839
 
 PODFILE CHECKSUM: d2a6b35e414b69177ba0b16fb76ad1eb91a4a929

--- a/react-native-google-maps.podspec
+++ b/react-native-google-maps.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.compiler_flags = '-DHAVE_GOOGLE_MAPS=1', '-DHAVE_GOOGLE_MAPS_UTILS=1', '-fno-modules'
 
   s.dependency 'React'
-  s.dependency 'GoogleMaps', '2.5.0'
+  s.dependency 'GoogleMaps', '3.0.3'
   s.dependency 'Google-Maps-iOS-Utils', '2.1.0'
 end


### PR DESCRIPTION
- Bumps Google Maps pod SDK to the latest version.
- Update example app

Replaces https://github.com/react-native-community/react-native-maps/pull/2753
Closes: https://github.com/react-native-community/react-native-maps/pull/2748