### PR TITLE
[AIRGoogleMap] Free instance variable in getActionForTarget

### DIFF
--- a/lib/ios/AirGoogleMaps/AIRGoogleMap.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMap.m
@@ -619,6 +619,7 @@ id regionAsJSON(MKCoordinateRegion region) {
             }
         }
     }
+    free(ivars);
     return action;
 }
 


### PR DESCRIPTION
Address memory leak issues reported in https://github.com/react-native-community/react-native-maps/issues/2782 and https://github.com/react-native-community/react-native-maps/issues/2775
Following up from https://github.com/react-native-community/react-native-maps/pull/2581
