### PR TITLE
Bugfix/accessibility

### DIFF
--- a/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -65,6 +65,7 @@ RCT_EXPORT_MODULE()
   return map;
 }
 
+RCT_REMAP_VIEW_PROPERTY(testID, accessibilityIdentifier, NSString)
 RCT_EXPORT_VIEW_PROPERTY(initialCamera, GMSCameraPosition)
 RCT_REMAP_VIEW_PROPERTY(camera, cameraProp, GMSCameraPosition)
 RCT_EXPORT_VIEW_PROPERTY(initialRegion, MKCoordinateRegion)

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -48,8 +48,8 @@ RCT_EXPORT_MODULE()
   AIRGoogleMap *map = [AIRGoogleMap new];
   map.bridge = self.bridge;
   map.delegate = self;
-  map.isAccessibilityElement = "YES";
-  map.accessibilityElementsHidden = "NO";
+  map.isAccessibilityElement = YES;
+  map.accessibilityElementsHidden = NO;
   map.settings.consumesGesturesInView = NO;
   map.indoorDisplay.delegate = self;
   self.map = map;

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapMarkerManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapMarkerManager.m
@@ -25,8 +25,8 @@ RCT_EXPORT_MODULE()
 //  tapGestureRecognizer.cancelsTouchesInView = NO;
 //  [marker addGestureRecognizer:tapGestureRecognizer];
   marker.bridge = self.bridge;
-  marker.isAccessibilityElement = "YES";
-  marker.accessibilityElementsHidden = "NO";
+  marker.isAccessibilityElement = YES;
+  marker.accessibilityElementsHidden = NO;
   return marker;
 }
 

--- a/lib/ios/AirMaps/AIRMapManager.m
+++ b/lib/ios/AirMaps/AIRMapManager.m
@@ -50,6 +50,9 @@ RCT_EXPORT_MODULE()
     AIRMap *map = [AIRMap new];
     map.delegate = self;
 
+    map.isAccessibilityElement = YES;
+    map.accessibilityElementsHidden = NO;
+    
     // MKMapView doesn't report tap events, so we attach gesture recognizers to it
     UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleMapTap:)];
     UILongPressGestureRecognizer *longPress = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleMapLongPress:)];
@@ -70,6 +73,7 @@ RCT_EXPORT_MODULE()
     return map;
 }
 
+RCT_REMAP_VIEW_PROPERTY(testID, accessibilityIdentifier, NSString)
 RCT_EXPORT_VIEW_PROPERTY(showsUserLocation, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(userLocationAnnotationTitle, NSString)
 RCT_EXPORT_VIEW_PROPERTY(followsUserLocation, BOOL)

--- a/lib/ios/AirMaps/AIRMapMarkerManager.m
+++ b/lib/ios/AirMaps/AIRMapMarkerManager.m
@@ -27,10 +27,13 @@ RCT_EXPORT_MODULE()
     AIRMapMarker *marker = [AIRMapMarker new];
     [marker addTapGestureRecognizer];
     marker.bridge = self.bridge;
+    marker.isAccessibilityElement = YES;
+    marker.accessibilityElementsHidden = NO;
     return marker;
 }
 
 RCT_EXPORT_VIEW_PROPERTY(identifier, NSString)
+RCT_REMAP_VIEW_PROPERTY(testID, accessibilityIdentifier, NSString)
 //RCT_EXPORT_VIEW_PROPERTY(reuseIdentifier, NSString)
 RCT_EXPORT_VIEW_PROPERTY(title, NSString)
 RCT_REMAP_VIEW_PROPERTY(description, subtitle, NSString)


### PR DESCRIPTION
### Does any other open PR do the same thing?

Nope. But a recent one did this partially: https://github.com/react-native-community/react-native-maps/pull/2253
It missed the MapViewManager for both Air and Google, and the MarkerManager for Air.
Also the boolean bugs which prevent the markers from being accessible in Xcode.

### What issue is this PR fixing?

#2252, #1104

### How did you test this PR?

By creating automation. Markers are still a pain point in XCUI, especially tapping them, so it is not solved completely. But at least they have their ids.

