### PR TITLE
Update google maps pods to 3.1.0

### DIFF
--- a/react-native-google-maps.podspec
+++ b/react-native-google-maps.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
   s.compiler_flags = '-DHAVE_GOOGLE_MAPS=1', '-DHAVE_GOOGLE_MAPS_UTILS=1', '-fno-modules'
 
   s.dependency 'React'
-  s.dependency 'GoogleMaps', '3.0.3'
+  s.dependency 'GoogleMaps', '3.1.0'
   s.dependency 'Google-Maps-iOS-Utils', '2.1.0'
 end


### PR DESCRIPTION
### Does any other open PR do the same thing?

No other PR does the same thing

### What issue is this PR fixing?

It fixes a error that occurs in react-native-google-maps 3.0.3 and not in 3.1.0

### How did you test this PR?

I tested it by changing the node modules in my project and the bug was fixed
iOS (android the bug did not occur)
on simulator 