### PR TITLE
fix: resolves react snapshot undefined warning

### DIFF
--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -537,7 +537,7 @@ class MapView extends React.Component {
     if (this.props.customMapStyle !== prevProps.customMapStyle) {
       this._updateStyle(this.props);
     }
-    return this.props.region;
+    return this.props.region || null;
   }
 
   componentDidUpdate(prevProps, prevState, region) {


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

No

### What issue is this PR fixing?

Resolves React warning being displayed when the `region` prop in `MapView` is `undefined`.  React requires a snapshot value (or null) to be provided (see warning message below).  This PR modifies `getSnapshotBeforeUpdate` in `MapView` to return `null` if `props.region` is `undefined`.


### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

Change is JS only and only affects library's interaction with React.  However, the change was also tested on Android (on device) and iOS (device and simulator) to confirm warning is no longer triggered.

Steps to recreate and test for change:

1. Create `MapView` without `region` prop defined, e.g.:
```
<MapView style={{flex: 1, width: '100%'}} />
```
2. Run react native app and observe React warning in debug mode.
![image](https://user-images.githubusercontent.com/23213119/59161275-e8f50a00-8b23-11e9-8903-dec96ea885e9.png)

3. Now test with changes in this PR, warning should disappear. 

<!--
Thanks for your contribution :)
-->
