### PR TITLE
fix: map style being set before map is ready

### DIFF
--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -534,7 +534,10 @@ class MapView extends React.Component {
   }
 
   getSnapshotBeforeUpdate(prevProps) {
-    if (this.state.isReady && this.props.customMapStyle !== prevProps.customMapStyle) {
+    if (
+      this.state.isReady &&
+      this.props.customMapStyle !== prevProps.customMapStyle
+    ) {
       this._updateStyle(this.props);
     }
     return this.props.region || null;

--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -534,7 +534,7 @@ class MapView extends React.Component {
   }
 
   getSnapshotBeforeUpdate(prevProps) {
-    if (this.props.customMapStyle !== prevProps.customMapStyle) {
+    if (this.state.isReady && this.props.customMapStyle !== prevProps.customMapStyle) {
       this._updateStyle(this.props);
     }
     return this.props.region || null;


### PR DESCRIPTION
### Does any other open PR do the same thing?

no

### What issue is this PR fixing?

In certain scenarios when custom map styling is applied, `getSnapshotBeforeUpdate` will try to apply custom styling using `this._updateStyle()` before Google Maps is instantiated on the native side.  This results in a crash on the native side as it's trying to set a property to the map which doesn't (yet) exist:

![image](https://user-images.githubusercontent.com/23213119/59553990-5c918e00-8fe0-11e9-8a88-8b139a8d3c1f.png)

This PR adds a check in `getSnapshotBeforeUpdate` to confirm the map is ready (`this.state.isReady`) before applying a custom style.

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

During testing, this crash was only seen on Android.  But there's no reason why it won't also occur on iOS, I just haven't seen it happen.

It's hard to reproduce the exact circumstances when this crash occurs since it's a race condition between the native side instantiating the Google Maps library and the React/JS side triggering a `render()`.  It helps to have a slow device, and seems to occur more frequently when there are props of the `MapView` (e.g. `initialRegion`) that are mutated soon after map is initially rendered.

Example code: https://gist.github.com/jxeeno/fec7e766cdc524ce373511650ccee202