### PR TITLE
Add library name override for AndroidX compatibility

### DIFF
--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -20,7 +20,7 @@ dependencies {
   compileOnly('com.facebook.react:react-native:+') {
     exclude group: 'com.android.support'
   }
-  implementation "com.android.support:appcompat-v7:${safeExtGet('supportLibVersion', '28.0.0')}"
+  implementation "${safeExtGet('coreLibName', 'com.android.support:appcompat-v7')}:${safeExtGet('supportLibVersion', '28.0.0')}"
   implementation "com.google.android.gms:play-services-base:${safeExtGet('playServicesVersion', '16.1.0')}"
   implementation "com.google.android.gms:play-services-maps:${safeExtGet('playServicesVersion', '16.1.0')}"
   implementation 'com.google.maps.android:android-maps-utils:0.5'


### PR DESCRIPTION
If you allow an override of the library name as well, the jetifier package works to make this
package AndroidX compatible in combination with an android/build.gradle ext{} block in apps that
override things to 'androidx.core' for coreLibName and '1.0.2' for supportLibVersion

<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

No

### What issue is this PR fixing?

I'm the [jetifier](https://github.com/mikehardy/jetifier) package maintainer. [I'm trying to get the ecosystem ready for react-native 0.60 which moves to AndroidX](https://github.com/react-native-community/discussions-and-proposals/issues/129#issuecomment-504169271). Your package is part of my test suite and it fails to compile with RN60

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

I have a test suite here that I use for jetifier:

https://github.com/mikehardy/rn-androidx-demo

It currently works for RN0.59 in combination with an app moved to AndroidX.

I'm working on an RN0.60 branch of it so that it will work with RN0.60 and AndroidX as well, and it appears your module works with RN0.59 but has a dependency snarl when combined with RN0.60 that can't be untangled unless the library can be overridden

<!--
Thanks for your contribution :)
-->
