### PR TITLE
Allow using onPanDrag while scrollEnabled=true

### DIFF
--- a/lib/ios/AirMaps/AIRMapManager.m
+++ b/lib/ios/AirMaps/AIRMapManager.m
@@ -60,7 +60,6 @@ RCT_EXPORT_MODULE()
     UILongPressGestureRecognizer *longPress = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleMapLongPress:)];
     UIPanGestureRecognizer *drag = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handleMapDrag:)];
     [drag setMinimumNumberOfTouches:1];
-    [drag setMaximumNumberOfTouches:1];
     // setting this to NO allows the parent MapView to continue receiving marker selection events
     tap.cancelsTouchesInView = NO;
     longPress.cancelsTouchesInView = NO;

--- a/lib/ios/AirMaps/AIRMapManager.m
+++ b/lib/ios/AirMaps/AIRMapManager.m
@@ -35,7 +35,9 @@
 static NSString *const RCTMapViewKey = @"MapView";
 
 
-@interface AIRMapManager() <MKMapViewDelegate>
+@interface AIRMapManager() <MKMapViewDelegate, UIGestureRecognizerDelegate>
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer;
 
 @end
 
@@ -65,6 +67,8 @@ RCT_EXPORT_MODULE()
 
     // disable drag by default
     drag.enabled = NO;
+    
+    drag.delegate = self;
 
     [map addGestureRecognizer:tap];
     [map addGestureRecognizer:longPress];
@@ -1247,6 +1251,10 @@ static int kDragCenterContext;
     double zoomLevel = AIRMapMaxZoomLevel - zoomExponent;
 
     return zoomLevel;
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+    return YES;
 }
 
 @end


### PR DESCRIPTION
### Does any other open PR do the same thing?

Previous work has been done in #2692 - where this was extracted from - and #2314. 

The previous PR, while good, has been open since February and has seen no activity lately. Also, there are some concerns regarding the API it defines, where `onZoom`, `onPinch` etc could be a better alternative. 

This PR is a much narrower scope than the previous one, and should be simpler to get merged. It also presents no conflict if the former one would get merged.

### What issue is this PR fixing?

Allows `onPanDrag` to be used while scrollEnabled is true, which is currently not supported. This seems like the best entry point for determining when the user has interacted with the Map. There are multiple requests relating to this requirement; #2756 #1038 #1620 (last not explicitly the same - but seems like the same base issue).

Also, removes the `[drag setMaximumNumberOfTouches:1];` call so that if one pans with more than one finger, the handler still fires. This is consistent with how it works on Android.

### How did you test this PR?

1. Create a Map component with an `onPanDrag` handler
2. Pan the map
3. onPanDrag should fire

# Verification

This is only enabled on iOS with Apple Maps. It's been tested both on the simulator and on device.

