### PR TITLE
Fix build gradle to allow jettifier to run correctly

### DIFF
--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -17,7 +17,7 @@ android {
 }
 
 dependencies {
-  compileOnly('com.facebook.react:react-native:+') {
+  implementation('com.facebook.react:react-native:+') {
     exclude group: 'com.android.support'
   }
   implementation "com.android.support:appcompat-v7:${safeExtGet('supportLibVersion', '28.0.0')}"


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

No current PR has this change, it solves the androidX migration without having to migrate this package.

### What issue is this PR fixing?

fixes #2940 

### How did you test this PR?
Simple dependency change `compileOnly` fails for android 60 that is using jettifier post install script.
Changing to implementation fixes the build problem and runs as before RN 0.60
