### PR TITLE
Fix playServicesVersion name in Android installation docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -220,7 +220,7 @@ ext {
     buildToolsVersion   = "xxx"
     minSdkVersion       = xxx
     supportLibVersion   = "xxx"
-    googlePlayServicesVersion = "xxx" // or set latest version
+    playServicesVersion = "xxx" // or set latest version
     androidMapsUtilsVersion = "xxx"
 }
 ```
@@ -233,7 +233,7 @@ buildscript {
         compileSdkVersion = xxx
         targetSdkVersion = xxx
         supportLibVersion = "xxx"
-        googlePlayServicesVersion = "xxx" // or set latest version
+        playServicesVersion = "xxx" // or set latest version
         androidMapsUtilsVersion = "xxx"
     }
 }


### PR DESCRIPTION
### Does any other open PR do the same thing?

Not that I could find

### What issue is this PR fixing?

This project's build.gradle files are using `playServicesVersion` ([1](https://github.com/react-native-community/react-native-maps/blob/4ee5d78ced9e3974a316e83703fc7e8023c497f8/build.gradle), [2](https://github.com/react-native-community/react-native-maps/blob/62bb953c19e55adb29200ecff9981eb5e594a7b3/lib/android/build.gradle#L24)), but the docs suggest setting `googlePlayServicesVersion` ([3](https://github.com/react-native-community/react-native-maps/blob/69e2f2582ef9ae49898f715e4f5940e17cdbc5ef/docs/installation.md#build-configuration-on-android)).

### How did you test this PR?

(please answer here)

<!--
Thanks for your contribution :)
-->
