### PR TITLE
Add heading to the onUserLocationChange listener

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -125,6 +125,7 @@ declare module "react-native-maps" {
         timestamp: number;
         accuracy: number;
         speed: number;
+        heading: number;
         isFromMockProvider: boolean;
       };
     };

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -224,6 +224,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
         coordinate.putDouble("timestamp", location.getTime());
         coordinate.putDouble("accuracy", location.getAccuracy());
         coordinate.putDouble("speed", location.getSpeed());
+        coordinate.putDouble("heading", location.getBearing());
         if(android.os.Build.VERSION.SDK_INT >= 18){
         coordinate.putBoolean("isFromMockProvider", location.isFromMockProvider());
         }

--- a/lib/ios/AirGoogleMaps/AIRGoogleMap.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMap.m
@@ -789,6 +789,7 @@ id regionAsJSON(MKCoordinateRegion region) {
                     @"accuracy": @(location.horizontalAccuracy),
                     @"altitudeAccuracy": @(location.verticalAccuracy),
                     @"speed": @(location.speed),
+                    @"heading": @(location.course),
                     }
                 };
 


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

As far as I can see, no.

### What issue is this PR fixing?

None actually. I was going to create one though, but it appeared that it would be easier to fix it myself. The thing is -- I am using `onUserLocationChange` listener in my app to get user's location, but I also need `heading`, and somehow it wasn't there.
But in comments of PR #2889, this also was requested.

### How did you test this PR?

I did it only with iPhone simulator. I added the listener to my map and then was setting `camera` property on it depending on the `heading` I get from the listener. It worked perfectly.
I probably gonna test it on a real android device at least, just don't have an opportunity to do it now.

<!--
Thanks for your contribution :)
-->
