### PR TITLE
"AIRMap" was not found in the UIManager IN "0.26.0"

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,8 +1,9 @@
 module.exports = {
-  project: {
-    ios: {},
-    android: {
-      sourceDir: './lib/android',
+  dependency: {
+    platforms: {
+      android: {
+        sourceDir: './lib/android',
+      },
     },
   },
 };


### PR DESCRIPTION
### Does any other open PR do the same thing?
NO
<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

No PR like this exists. It solves the issue of AIRMAP not found error while building on android screen.

### What issue is this PR fixing?

"AIRMap" was not found in the UIManager IN "0.26.0"
https://github.com/react-native-community/react-native-maps/issues/3099

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

I tested the PR using the react-native-maps on my real time project on real devices android and iOS

<!--
Thanks for your contribution :)
-->
