### PR TITLE
only handle cacheEnable when app is active

### DIFF
--- a/lib/ios/AirMaps/AIRMap.m
+++ b/lib/ios/AirMaps/AIRMap.m
@@ -526,6 +526,11 @@ const NSInteger AIRMapMaxZoomLevel = 20;
 }
 
 - (void)cacheViewIfNeeded {
+    // https://github.com/react-native-community/react-native-maps/issues/3100
+    // Do nothing if app is not active
+    if ([[UIApplication sharedApplication] applicationState] != UIApplicationStateActive) {
+        return;
+    }
     if (self.hasShownInitialLoading) {
         if (!self.cacheEnabled) {
             if (_cacheImageView != nil) {


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

No

### What issue is this PR fixing?
#3100 
MapView went black in iOS (apple map) with `cacheEnable` when switching to other apps or goes to background

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

Local test on my phone.
Step 1. Open mapview with cacheEnable
Step 2. Switch to other apps then switch back -> mapview still visible
Step 3. Hide app to background then open again -> mapview still visible

<!--
Thanks for your contribution :)
-->
