### PR TITLE
Add supportLibVersion safeguard in gradle build

### DIFF
--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -17,6 +17,7 @@ android {
 }
 
 dependencies {
+  def supportLibVersion = safeExtGet('supportLibVersion', '28.0.0')
   def supportLibMajorVersion = supportLibVersion.split('\\.')[0] as int
   def appCompatLibName =  (supportLibMajorVersion < 20) ? "androidx.appcompat:appcompat" : "com.android.support:appcompat-v7"
   implementation "$appCompatLibName:$supportLibVersion"


### PR DESCRIPTION
### Does any other open PR do the same thing?

Not that I can see

### What issue is this PR fixing?

In 801614efcdca00fa2dbad89fca6af1607b4184e1 support for react native 0.60.5 was added, however it didn't safely check if `supportLibVersion` was set, which broke my build. A simple change like this fixed this issue.

Commit message:
```
This change makes sure that we safely check to see if supportLibVersion
is set before we try to use this.
```

### How did you test this PR?

Before this change nothing would build, but with this change it builds just fine.