### PR TITLE
[iOS] Expose isAccessibilityElement as a prop

### DIFF
--- a/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapManager.m
@@ -65,6 +65,7 @@ RCT_EXPORT_MODULE()
   return map;
 }
 
+RCT_EXPORT_VIEW_PROPERTY(isAccessibilityElement, BOOL)
 RCT_REMAP_VIEW_PROPERTY(testID, accessibilityIdentifier, NSString)
 RCT_EXPORT_VIEW_PROPERTY(initialCamera, GMSCameraPosition)
 RCT_REMAP_VIEW_PROPERTY(camera, cameraProp, GMSCameraPosition)

--- a/lib/ios/AirMaps/AIRMapManager.m
+++ b/lib/ios/AirMaps/AIRMapManager.m
@@ -83,6 +83,7 @@ RCT_EXPORT_MODULE()
     return map;
 }
 
+RCT_EXPORT_VIEW_PROPERTY(isAccessibilityElement, BOOL)
 RCT_REMAP_VIEW_PROPERTY(testID, accessibilityIdentifier, NSString)
 RCT_EXPORT_VIEW_PROPERTY(showsUserLocation, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(userLocationAnnotationTitle, NSString)


### PR DESCRIPTION
### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

https://github.com/react-native-community/react-native-maps/issues/3114

When the MapView has `isAccessibilityElement: YES`, the map captures any accessibility taps and does not forward them on to the markers. Passing an `isAccessibilityElement` prop allows the developer to expose map children (ie markers) to VoiceOver and/or other accessibility tools.

### How did you test this PR?

- Created a map with custom markers.
- Set `isAccessibilityElement: false` on map.
- Turned VoiceOver on
- Tapped on markers
- Verified that VoiceOver recognized markers, allowed me to tap into them
