### PR TITLE
replaced deprecated bridge.imageLoader calls with moduleForClass API

### DIFF
--- a/lib/ios/AirGoogleMaps/AIRGoogleMapMarker.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapMarker.m
@@ -270,7 +270,7 @@ CGRect unionRect(CGRect a, CGRect b) {
     [self iconViewInsertSubview:_iconImageView atIndex:0];
   }
 
-  _reloadImageCancellationBlock = [_bridge.imageLoader loadImageWithURLRequest:[RCTConvert NSURLRequest:_imageSrc]
+  _reloadImageCancellationBlock = [[_bridge moduleForClass:[RCTImageLoader class]] loadImageWithURLRequest:[RCTConvert NSURLRequest:_imageSrc]
                                                                           size:self.bounds.size
                                                                          scale:RCTScreenScale()
                                                                        clipped:YES
@@ -327,7 +327,7 @@ CGRect unionRect(CGRect a, CGRect b) {
   }
 
   _reloadImageCancellationBlock =
-  [_bridge.imageLoader loadImageWithURLRequest:[RCTConvert NSURLRequest:_iconSrc]
+  [[_bridge moduleForClass:[RCTImageLoader class]] loadImageWithURLRequest:[RCTConvert NSURLRequest:_iconSrc]
                                           size:self.bounds.size
                                          scale:RCTScreenScale()
                                        clipped:YES

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapOverlay.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapOverlay.m
@@ -42,7 +42,7 @@
   }
 
   __weak typeof(self) weakSelf = self;
-  _reloadImageCancellationBlock = [_bridge.imageLoader loadImageWithURLRequest:[RCTConvert NSURLRequest:_imageSrc]
+  _reloadImageCancellationBlock = [[_bridge moduleForClass:[RCTImageLoader class]] loadImageWithURLRequest:[RCTConvert NSURLRequest:_imageSrc]
                                                                           size:weakSelf.bounds.size
                                                                          scale:RCTScreenScale()
                                                                        clipped:YES

--- a/lib/ios/AirMaps/AIRMapMarker.m
+++ b/lib/ios/AirMaps/AIRMapMarker.m
@@ -314,7 +314,7 @@ NSInteger const AIR_CALLOUT_OPEN_ZINDEX_BASELINE = 999;
         _reloadImageCancellationBlock();
         _reloadImageCancellationBlock = nil;
     }
-    _reloadImageCancellationBlock = [_bridge.imageLoader loadImageWithURLRequest:[RCTConvert NSURLRequest:_imageSrc]
+    _reloadImageCancellationBlock = [[_bridge moduleForClass:[RCTImageLoader class]] loadImageWithURLRequest:[RCTConvert NSURLRequest:_imageSrc]
                                                                             size:self.bounds.size
                                                                            scale:RCTScreenScale()
                                                                          clipped:YES

--- a/lib/ios/AirMaps/AIRMapOverlay.m
+++ b/lib/ios/AirMaps/AIRMapOverlay.m
@@ -27,7 +27,7 @@
         _reloadImageCancellationBlock = nil;
     }
     __weak typeof(self) weakSelf = self;
-    _reloadImageCancellationBlock = [_bridge.imageLoader loadImageWithURLRequest:[RCTConvert NSURLRequest:_imageSrc]
+    _reloadImageCancellationBlock = [[_bridge moduleForClass:[RCTImageLoader class]] loadImageWithURLRequest:[RCTConvert NSURLRequest:_imageSrc]
                                                                             size:weakSelf.bounds.size
                                                                            scale:RCTScreenScale()
                                                                          clipped:YES


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

No

### What issue is this PR fixing?

#3094 
### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

I tested on a new react native project running on version 0.61.2 and observed that the deprecation warnings no longer appear after implementing the `moduleForClass` API and tested to make sure that Marker and Map overlay images load correctly after API changes
<!--
Thanks for your contribution :)
-->
