### PR TITLE
Wider Note column (prevent horisontal scroll)

### DIFF
--- a/docs/mapview.md
+++ b/docs/mapview.md
@@ -10,7 +10,7 @@
 | `camera` | `Camera` |  | The camera view the map should display. If you use this, the `region` property is ignored.
 | `initialCamera` | `Camera` |  | Like `initialRegion`, use this prop instead of `camera` only if you don't want to control the viewport of the map besides the initial camera setting.<br/><br/> Changing this prop after the component has mounted will not result in a region change.<br/><br/> This is similar to the `initialValue` prop of a text input.
 | `mapPadding` | `EdgePadding` |  | Adds custom padding to each side of the map. Useful when map elements/markers are obscured.
-| `paddingAdjustmentBehavior` | 'always'\|'automatic'\|'never' | 'never' | Indicates how/when to affect padding with safe area insets (`GoogleMaps` in iOS only)
+| `paddingAdjustmentBehavior` | 'always' \| 'automatic' \| 'never' | 'never' | Indicates how/when to affect padding with safe area insets (`GoogleMaps` in iOS only)
 | `liteMode` | `Boolean` | `false` | Enable lite mode. **Note**: Android only.
 | `mapType` | `String` | `"standard"` | The map type to be displayed. <br/><br/> - standard: standard road map (default)<br/> - none: no map **Note** Not available on MapKit<br/> - satellite: satellite view<br/> - hybrid: satellite view with roads and points of interest overlayed<br/> - terrain: (Android only) topographic view<br/> - mutedStandard: more subtle, makes markers/lines pop more (iOS 11.0+ only)
 | `customMapStyle` | `Array` |  | Adds custom styling to the map component. See [README](https://github.com/react-native-community/react-native-maps#customizing-the-map-style) for more information.


### PR DESCRIPTION
Line break types for "paddingAdjustmentBehavior" to decrease type-column width which increases Note column width. It was hard to browse props when Prop and Note columns were not visible at the same time (due to horisontal scroll in table and hidden overflow).

### Does any other open PR do the same thing?
No.

### What issue is this PR fixing?
It was hard to browse props when Prop and Note columns were not visible at the same time (due to horisontal scroll in table and hidden overflow).

### How did you test this PR?
Checked the preview tab on GitHub.
