### PR TITLE
Corrected issue with _mapRect calculation causing negative height and Overlay image clipping.

### DIFF
--- a/lib/ios/AirMaps/AIRMapOverlay.m
+++ b/lib/ios/AirMaps/AIRMapOverlay.m
@@ -56,7 +56,7 @@
     MKMapPoint southWest = MKMapPointForCoordinate(_southWest);
     MKMapPoint northEast = MKMapPointForCoordinate(_northEast);
 
-    _mapRect = MKMapRectMake(southWest.x, northEast.y, northEast.x - southWest.x, northEast.y - southWest.y);
+    _mapRect = MKMapRectMake(southWest.x, northEast.y, ABS(northEast.x - southWest.x), ABS(northEast.y - southWest.y));
 
     [self update];
 }

--- a/lib/ios/AirMaps/AIRMapOverlayRenderer.m
+++ b/lib/ios/AirMaps/AIRMapOverlayRenderer.m
@@ -15,6 +15,7 @@
     
     CGContextRotateCTM(context, M_PI);
     CGContextScaleCTM(context, -1.0, 1.0);
+    CGContextTranslateCTM(context, 0.0, -theRect.size.height);
     CGContextAddRect(context, theRect);
     CGContextDrawImage(context, theRect, imageReference);
     


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

No

### What issue is this PR fixing?

The _mapRect generated from the MKMapRectMake() method was returning a negative height. This caused an invalid boundingMapRect, causing clipping of the overlay. The problem seems more pronounced on iOS 13.

possibly https://github.com/react-native-community/react-native-maps/issues/2801

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

iOS AirMap only. Tested on real device and simulator.
Problem seems more pronounced on iOS 13.

Create clean react-native project, using latest react-native-maps. Add overlay with bounds within north/west hemisphere. Zoom into the overlay. Clipping should not happen and full overlay should be displayed in the correct location and size.

Was not tested in any other hemisphere.

<!--
Thanks for your contribution :)
-->
