### PR TITLE
Add missing MapUrlTileProps to index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -437,9 +437,12 @@ declare module "react-native-maps" {
 
   export interface MapUrlTileProps extends ViewProperties {
     urlTemplate: string;
+    minimumZ?: number;
     maximumZ?: number;
     zIndex?: number;
     tileSize?: number;
+    shouldReplaceMapContent?:boolean;
+    flipY?: boolean;
   }
 
   export class UrlTile extends React.Component<MapUrlTileProps, any> {}


### PR DESCRIPTION
These types are inline with the `propTypes` in `lib/components/MapUrlTile.js`

### Does any other open PR do the same thing?

Not that I can see, but if #2877 goes ahead, then the change might need to be made elsewhere as well. FWIW I prefer the typedefs here, rather than having to install yet another `@types/...` package.

### What issue is this PR fixing?

typescript & IDE complaining about missing types

### How did you test this PR?

I didn't. I made this edit directly in GitHub
