### PR TITLE
Added paddingAdjustmentBehavior to MapViewProps TS def

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -212,6 +212,7 @@ declare module "react-native-maps" {
     initialCamera?: Camera;
     liteMode?: boolean;
     mapPadding?: EdgePadding;
+    paddingAdjustmentBehavior?: "always" | "automatic" | "never";
     maxDelta?: number;
     minDelta?: number;
     legalLabelInsets?: EdgeInsets;


### PR DESCRIPTION
The optional iOS Google Maps prop is missing from the TypeScript definition file.

### Does any other open PR do the same thing?

No

### What issue is this PR fixing?

TypeScript definition for MapViewProps

### How did you test this PR?

TypeScript error about `paddingAdjustmentBehavior` missing on MapView went away.
