### PR TITLE
Implement opacity prop for MapOverlay on Android and iOS (Google Maps)

### DIFF
--- a/docs/overlay.md
+++ b/docs/overlay.md
@@ -7,6 +7,7 @@
 | `image` | `ImageSource` | A custom image to be used as the overlay. Only required local image resources and uri (as for images located in the net) are allowed to be used.
 | `bounds` | `Array<LatLng>` |  | The coordinates for the image (left-top corner, right-bottom corner). ie.```[[lat, long], [lat, long]]```
 | `tappable` | `Bool` | `false` | `Android only` Boolean to allow an overlay to be tappable and use the onPress function.
+| `opacity` | `Number` | `1.0` | `Google maps only` The opacity of the overlay.
 
 ## Events
 

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapOverlay.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapOverlay.java
@@ -50,12 +50,12 @@ public class AirMapOverlay extends AirMapFeature implements ImageReadable {
     }
   }
 
-  // public void setTransparency(float transparency) {
-  //     this.transparency = transparency;
-  //     if (groundOverlay != null) {
-  //         groundOverlay.setTransparency(transparency);
-  //     }
-  // }
+  public void setTransparency(float transparency) {
+      this.transparency = transparency;
+      if (groundOverlay != null) {
+          groundOverlay.setTransparency(transparency);
+      }
+  }
 
   public void setImage(String uri) {
     this.mImageReader.setImage(uri);
@@ -138,6 +138,7 @@ public class AirMapOverlay extends AirMapFeature implements ImageReadable {
     if (this.groundOverlay != null) {
       this.groundOverlay.setVisible(true);
       this.groundOverlay.setImage(this.iconBitmapDescriptor);
+      this.groundOverlay.setTransparency(this.transparency);
       this.groundOverlay.setClickable(this.tappable);
     }
   }

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapOverlayManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapOverlayManager.java
@@ -51,10 +51,10 @@ public class AirMapOverlayManager extends ViewGroupManager<AirMapOverlay> {
     view.setZIndex(zIndex);
   }
 
-  // @ReactProp(name = "transparency", defaultFloat = 1.0f)
-  // public void setTransparency(AirMapOverlay view, float transparency) {
-  //   view.setTransparency(transparency);
-  // }
+  @ReactProp(name = "opacity", defaultFloat = 1.0f)
+  public void setOpacity(AirMapOverlay view, float opacity) {
+    view.setTransparency(1 - opacity);
+  }
 
   @ReactProp(name = "image")
   public void setImage(AirMapOverlay view, @Nullable String source) {

--- a/lib/components/MapOverlay.js
+++ b/lib/components/MapOverlay.js
@@ -26,6 +26,8 @@ const propTypes = {
   tappable: PropTypes.bool,
   // Callback that is called when the user presses on the overlay
   onPress: PropTypes.func,
+  // The opacity of the overlay.
+  opacity: PropTypes.number,
 };
 
 class MapOverlay extends Component {
@@ -57,6 +59,9 @@ class MapOverlay extends Component {
 
 MapOverlay.propTypes = propTypes;
 MapOverlay.viewConfig = viewConfig;
+MapOverlay.defaultProps = {
+  opacity: 1.0,
+};
 
 const styles = StyleSheet.create({
   overlay: {

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapOverlay.h
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapOverlay.h
@@ -18,6 +18,7 @@
 @property (nonatomic, copy) NSString *imageSrc;
 @property (nonatomic, strong, readonly) UIImage *overlayImage;
 @property (nonatomic, copy) NSArray *boundsRect;
+@property (nonatomic, assign) CGFloat opacity;
 @property (nonatomic, readonly) GMSCoordinateBounds *overlayBounds;
 
 @property (nonatomic, weak) RCTBridge *bridge;

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapOverlay.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapOverlay.m
@@ -75,6 +75,11 @@
   _overlay.bounds = _overlayBounds;
 }
 
+- (void)setOpacity:(CGFloat)opacity
+{
+  _overlay.opacity = opacity;
+}
+
 @end
 
 #endif

--- a/lib/ios/AirGoogleMaps/AIRGoogleMapOverlayManager.m
+++ b/lib/ios/AirGoogleMaps/AIRGoogleMapOverlayManager.m
@@ -18,5 +18,6 @@ RCT_EXPORT_MODULE()
 
 RCT_REMAP_VIEW_PROPERTY(bounds, boundsRect, NSArray)
 RCT_REMAP_VIEW_PROPERTY(image, imageSrc, NSString)
+RCT_REMAP_VIEW_PROPERTY(opacity, opacity, CGFloat)
 
 @end


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

No.

### What issue is this PR fixing?

We needed the ability to control the transparency/opacity of Overlay components. For some reason, the transparency control for GroundOverlay was commented out for [Android](https://github.com/react-native-community/react-native-maps/blob/master/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapOverlay.java#L53) and was never implemented for iOS.

The `transparency` option was implemented as `opacity` as the rest of this project seems to prefer `opacity`, and both platforms implemented it differently as well.

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

Tested on an android emulator and iOS simulator using `react-native@0.61.0` and using the branch HEAD `"react-native-maps": "git://github.com/Crop-R/react-native-maps.git#5ee80e8d1e5af9962937d5db578d333fef4d35cb"` as a dependency. We pass an image url to the `image` prop of `MapView.Overlay`.

<!--
Thanks for your contribution :)
-->
