### PR TITLE
Add installation instruction about NSLocationWhenInUseUsageDescription

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -126,6 +126,9 @@ and open the produced workspace file (`.xcworkspace`) in XCode to build your pro
 cd ios
 pod install
 ```
+### App store submission
+
+The app's `Info.plist` file must contain a `NSLocationWhenInUseUsageDescription` with a user-facing purpose string explaining clearly and completely why your app needs the location, otherwise Apple will reject your app submission.
 
 ### Enabling Google Maps on iOS (React Native all versions)
 


### PR DESCRIPTION
### Does any other open PR do the same thing?
No

### What issue is this PR fixing?

#1947

When submitting to app store
```
ITMS-90683: Missing Purpose String in Info.plist - Your app's code references one or more APIs that access sensitive user data. 
The app's Info.plist file should contain a NSLocationWhenInUseUsageDescription key with a user-facing purpose string explaining clearly and completely why your app needs the data. 
Starting Spring 2019, all apps submitted to the App Store that access user data are required to include a purpose string. 
If you're using external libraries or SDKs, they may reference APIs that require a purpose string. 
While your app might not use these APIs, a purpose string is still required. 
You can contact the developer of the library or SDK and request they release a version of their code that doesn't contain the APIs. 
Learn more (https://developer.apple.com/documentation/uikit/core_app/protecting_the_user_s_privacy).
```

### How did you test this PR?

MD
