### PR TITLE
#3025 Fixes for polygon custom styles (fillColor, stokeColor, stokeWidth) not being applied on iOS devices when provider is Google maps.

### DIFF
--- a/lib/components/MapPolygon.js
+++ b/lib/components/MapPolygon.js
@@ -179,7 +179,9 @@ class MapPolygon extends React.Component {
           this.polygon = ref;
         }}
         onLayout={
-          this.context.provider === MapView.PROVIDER_GOOGLE ? this.updateNativeProps() : undefined
+          this.context.provider === MapView.PROVIDER_GOOGLE
+            ? this.updateNativeProps()
+            : undefined
         }
       />
     );


### PR DESCRIPTION
Taking https://github.com/react-native-community/react-native-maps/issues/3025#issuecomment-522968087 as a reference. Apply `fillColor`, `stokeColor` and `stokeWidth` to polygons after the layout is calculated. 

### Does any other open PR do the same thing?

A few related issues (https://github.com/react-native-community/react-native-maps/issues/3025#issuecomment-522968087, https://github.com/react-native-community/react-native-maps/issues/2867#issuecomment-573739457 ) were brought up and some comments indicated some temporary fix. However, no PR was found.

### What issue is this PR fixing?
This issue was found while testing GeoJSON. In `Geojson` component, I passed in multiple style related props, `fillColor`, `strokeColor`, and `strokeWidth`. However, in iOS simulator, I could only see the default style (purple with opacity) being applied when using Google maps. 
```
<Geojson 
    geojson={geoJsonData} 
    strokeColor="rgba(255, 0, 0, 0.7)"
    fillColor="rgba(0, 255, 0, 0.4)"
    strokeWidth={3}
/>
```
As the screenshot below.
![Simulator Screen Shot - iPhone X - 2020-02-26 at 14 34 32](https://user-images.githubusercontent.com/16603120/75394542-3299a680-58a5-11ea-9afc-683b3b9985ef.png)

Related issues found in repo.
https://github.com/react-native-community/react-native-maps/issues/3025#issuecomment-522968087, https://github.com/react-native-community/react-native-maps/issues/2867#issuecomment-573739457

### How did you test this PR?

Tested on both iOS and Android simulator. Screenshots attached. `geoJsonData` used in the code snippet below is from Google office documentation. https://developers.google.com/maps/documentation/javascript/datalayer#googlejson
```
<Geojson 
    geojson={geoJsonData} 
    strokeColor="rgba(255, 0, 0, 0.7)"
    fillColor="rgba(0, 255, 0, 0.4)"
    strokeWidth={3}
/>
```
![Screenshot_1582755900](https://user-images.githubusercontent.com/16603120/75393898-ea2db900-58a3-11ea-848b-3383d7f729fd.png)
![Simulator Screen Shot - iPhone X - 2020-02-26 at 14 26 08](https://user-images.githubusercontent.com/16603120/75393927-f4e84e00-58a3-11ea-9d6a-b162f18f79be.png)
