### PR TITLE
Fixed fused location source

### DIFF
--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -24,8 +24,8 @@ dependencies {
   implementation('com.facebook.react:react-native:+') {
     exclude group: 'com.android.support'
   }
-  implementation "com.google.android.gms:play-services-base:${safeExtGet('playServicesVersion', '16.1.0')}"
-  implementation "com.google.android.gms:play-services-maps:${safeExtGet('playServicesVersion', '16.1.0')}"
+  implementation "com.google.android.gms:play-services-base:${safeExtGet('playServicesVersion', '17.1.0')}"
+  implementation "com.google.android.gms:play-services-maps:${safeExtGet('playServicesVersion', '17.1.0')}"
   implementation "com.google.android.gms:play-services-location:17.0.0"
   implementation 'com.google.maps.android:android-maps-utils:0.5'
 }

--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -26,5 +26,6 @@ dependencies {
   }
   implementation "com.google.android.gms:play-services-base:${safeExtGet('playServicesVersion', '16.1.0')}"
   implementation "com.google.android.gms:play-services-maps:${safeExtGet('playServicesVersion', '16.1.0')}"
+  implementation "com.google.android.gms:play-services-location:17.0.0"
   implementation 'com.google.maps.android:android-maps-utils:0.5'
 }

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -112,6 +112,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
   private boolean destroyed = false;
   private final ThemedReactContext context;
   private final EventDispatcher eventDispatcher;
+  private FusedLocationSource fusedLocationSource;
 
   private ViewAttacherGroup attacherGroup;
 
@@ -160,6 +161,8 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
     super.getMapAsync(this);
 
     final AirMapView view = this;
+
+    fusedLocationSource = new FusedLocationSource(context);
 
     gestureDetector =
         new GestureDetectorCompat(reactContext, new GestureDetector.SimpleOnGestureListener() {
@@ -385,6 +388,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
         if (hasPermissions()) {
           //noinspection MissingPermission
           map.setMyLocationEnabled(showUserLocation);
+          map.setLocationSource(fusedLocationSource);
         }
         synchronized (AirMapView.this) {
           if (!destroyed) {
@@ -513,9 +517,22 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
   public void setShowsUserLocation(boolean showUserLocation) {
     this.showUserLocation = showUserLocation; // hold onto this for lifecycle handling
     if (hasPermissions()) {
+      map.setLocationSource(fusedLocationSource);
       //noinspection MissingPermission
       map.setMyLocationEnabled(showUserLocation);
     }
+  }
+
+  public void setUserLocationPriority(int priority){
+    fusedLocationSource.setPriority(priority);
+  }
+
+  public void setUserLocationUpdateInterval(int interval){
+    fusedLocationSource.setInterval(interval);
+  }
+
+  public void setUserLocationFastestInterval(int interval){
+    fusedLocationSource.setFastestInterval(interval);
   }
 
   public void setShowsMyLocationButton(boolean showMyLocationButton) {


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

No.

### What issue is this PR fixing?

#3282 and #2923

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

Set up a test RN project with my fork as a dependency, exported bundled APK to a OnePlus 6 and went outside for a walk. Compared user location continuosly with the Google Maps app.

**Note 1** 

When I try to run *example-android* it fails with the following error. However, when I add my fork to a test RN project it builds fine. I have not succeeded identifying the cause.

```
ERROR: Manifest merger failed : Attribute application@appComponentFactory value=(android.support.v4.app.CoreComponentFactory) from [com.android.support:support-compat:28.0.0] AndroidManifest.xml:22:18-91
	is also present at [androidx.core:core:1.0.0] AndroidManifest.xml:22:18-86 value=(androidx.core.app.CoreComponentFactory).
	Suggestion: add 'tools:replace="android:appComponentFactory"' to <application> element at manifestMerger2158610616111590745.xml:7:5-9:19 to override.
```
**Note 2**

The line `implementation "com.google.android.gms:play-services-location:17.0.0"` needs to have an explicit version number. Using 16.1.0 breaks because of androidx, and version 16.0.0 of play-services-location simply does not exist. I guess it will be sorted out in time, and '17.0.0' can be changed to the safeExtGet value in time. 