### PR TITLE
feat: add the ability to pass a Marker image as Geojson prop

### DIFF
--- a/lib/components/Geojson.js
+++ b/lib/components/Geojson.js
@@ -105,6 +105,7 @@ const Geojson = props => {
             <Marker
               key={index}
               coordinate={overlay.coordinates}
+              image={props.image}
               pinColor={props.color}
             />
           );


### PR DESCRIPTION
### Does any other open PR do the same thing?
No.

### What issue is this PR fixing?
This PR adds the ability to pass an image as props to a Geojson component. Thus, the image used for geojson markers can now be customized.

Related to this issue: https://github.com/react-native-community/react-native-maps/issues/3450

### How did you test this PR?
Tested on both Android and iOS simulators.

