### PR TITLE
Added 'useNativeDriver: false' to Animated.timing to suppress warnings in React Native v0.62

### DIFF
--- a/lib/components/AnimatedRegion.js
+++ b/lib/components/AnimatedRegion.js
@@ -162,6 +162,7 @@ export default class AnimatedMapRegion extends AnimatedWithChildren {
         Animated.timing(this.latitude, {
           ...config,
           toValue: config.latitude,
+          useNativeDriver: false
         })
       );
 
@@ -170,6 +171,7 @@ export default class AnimatedMapRegion extends AnimatedWithChildren {
         Animated.timing(this.longitude, {
           ...config,
           toValue: config.longitude,
+          useNativeDriver: false
         })
       );
 
@@ -178,6 +180,7 @@ export default class AnimatedMapRegion extends AnimatedWithChildren {
         Animated.timing(this.latitudeDelta, {
           ...config,
           toValue: config.latitudeDelta,
+          useNativeDriver: false
         })
       );
 
@@ -186,6 +189,7 @@ export default class AnimatedMapRegion extends AnimatedWithChildren {
         Animated.timing(this.longitudeDelta, {
           ...config,
           toValue: config.longitudeDelta,
+          useNativeDriver: false
         })
       );
 


### PR DESCRIPTION

<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

No

### What issue is this PR fixing?

When using React Native v0.62, a consistent warning will generate when using an animated region and animated marker. The warning (seen below) can be suppressed on iOS by setting the option `useNativeDriver: false` in `AnimatedRegion.js`.

[Issue](https://github.com/react-native-community/react-native-maps/issues/3483)

Warning: `Animated: 'useNativeDriver' was not specified. This is a required option and must be explicitly set to 'true' or 'false'`

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

I created an animated marker and then used an animated region when generating the coordinate. I then ran the build on my iPhone 11 Pro Max using xcode on iOS 13.5. The warnings that used to pop up no longer popped up.

<!--
Thanks for your contribution :)
-->
