### PR TITLE
Fix verbiage for lower and higher react-native version

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,7 +40,7 @@ Maps backend.
 
 ## Build configuration on iOS
 
-### Using React Native Link (React Native 0.59 and lower)
+### Using React Native Link (React Native 0.59 and higher)
 
 Run `react-native link react-native-maps` after which you should be able
 to use this library on iOS. Note that by default this will use Apple


### PR DESCRIPTION
Does any other open PR do the same thing?
No

What issue is this PR fixing?
Updates documentation to reference react-native 0.60 and up instead of two references to the same version

How did you test this PR?
Doesn't need testing. It's just a documentation update.